### PR TITLE
Fixed height reference for the angle label to correct the display in Cesium2D

### DIFF
--- a/lib/Models/UserDrawing.ts
+++ b/lib/Models/UserDrawing.ts
@@ -678,7 +678,7 @@ export default class UserDrawing extends MappableMixin(
         fillColor: Color.DARKBLUE,
         outlineColor: Color.WHITE,
         outlineWidth: 4,
-        heightReference: HeightReference.CLAMP_TO_GROUND,
+        heightReference: this.labelHeightReference,
         disableDepthTestDistance: Number.POSITIVE_INFINITY,
         pixelOffset: new Cartesian2(0, -16),
         verticalOrigin: VerticalOrigin.BOTTOM


### PR DESCRIPTION
Fixed the angle label height reference by replacing HeightReference.CLAMP_TO_GROUND with this.labelHeightReference, allowing the correct height reference to be selected based on the current viewer mode.