### PR TITLE
Implemented RER POI Catalog with filtering, styling, and 2D support

### DIFF
--- a/lib/Map/Leaflet/LeafletVisualizer.ts
+++ b/lib/Map/Leaflet/LeafletVisualizer.ts
@@ -20,6 +20,12 @@ import Property from "terriajs-cesium/Source/DataSources/Property";
 import isDefined from "../../Core/isDefined";
 import { getLineStyleLeaflet } from "../../Models/Catalog/Esri/esriLineStyle";
 import LeafletScene from "./LeafletScene";
+import "leaflet.markercluster";
+import PinBuilder from "terriajs-cesium/Source/Core/PinBuilder";
+import {
+  LeafletClusteringConfig,
+  LEAFLET_CLUSTERING_CONFIG_KEY
+} from "../../ModelMixins/GeojsonMixin";
 
 interface PointDetails {
   layer?: L.CircleMarker;
@@ -108,13 +114,14 @@ class LeafletGeomVisualizer {
 
   constructor(
     readonly leafletScene: LeafletScene,
-    readonly entityCollection: EntityCollection
+    readonly entityCollection: EntityCollection,
+    private readonly _clusteringConfig?: LeafletClusteringConfig
   ) {
     entityCollection.collectionChanged.addEventListener(
       this._onCollectionChanged,
       this
     );
-    this._featureGroup = L.featureGroup().addTo(leafletScene.map);
+    this._featureGroup = this._createFeatureGroup().addTo(leafletScene.map);
     this._entitiesToVisualize = new AssociativeArray();
     this._entityHash = {};
 
@@ -124,6 +131,44 @@ class LeafletGeomVisualizer {
       [],
       []
     );
+  }
+
+  private _createFeatureGroup(): L.FeatureGroup {
+    const cfg = this._clusteringConfig;
+
+    if (!cfg?.enabled || typeof (L as any).markerClusterGroup !== "function") {
+      return L.featureGroup();
+    }
+
+    const pinBuilder = new PinBuilder();
+    const pinColor = Color.fromCssColorString(cfg.pinBackgroundColor);
+    const pinSize = cfg.pinSize;
+    const pinCache = new Map<number, string>();
+
+    return (L as any).markerClusterGroup({
+      maxClusterRadius: cfg.pixelRange,
+      minimumClusterSize: cfg.minimumClusterSize,
+      showCoverageOnHover: false,
+      zoomToBoundsOnClick: true,
+      spiderfyOnMaxZoom: true,
+
+      iconCreateFunction: (cluster: any) => {
+        const count: number = cluster.getChildCount();
+
+        let dataUrl = pinCache.get(count);
+        if (!dataUrl) {
+          dataUrl = pinBuilder
+            .fromText(count.toLocaleString(), pinColor, pinSize)
+            .toDataURL();
+          pinCache.set(count, dataUrl);
+        }
+
+        return L.icon({
+          iconUrl: dataUrl,
+          iconSize: [pinSize, pinSize]
+        });
+      }
+    });
   }
 
   private _onCollectionChanged(
@@ -1358,6 +1403,11 @@ export default class LeafletVisualizer {
     dataSource: DataSource
   ) {
     const entities = dataSource.entities;
-    return [new LeafletGeomVisualizer(leafletScene, entities)];
+    const clusteringConfig: LeafletClusteringConfig | undefined = (
+      dataSource as any
+    )[LEAFLET_CLUSTERING_CONFIG_KEY];
+    return [
+      new LeafletGeomVisualizer(leafletScene, entities, clusteringConfig)
+    ];
   }
 }

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -16,6 +16,7 @@ import {
   Properties
 } from "@turf/helpers";
 import i18next from "i18next";
+import ViewerMode from "../Models/ViewerMode";
 import {
   action,
   computed,
@@ -1452,7 +1453,9 @@ function GeoJsonMixin<T extends Constructor<BaseType>>(Base: T) {
       this.applyMixedStyle(dataSource);
 
       if (isRerPoiUrl(this.url) && this.type !== RER_POI_CATALOG_ITEM_TYPE) {
-        applyRerPoiEntityStyles(dataSource, dataSource.entities.values);
+        applyRerPoiEntityStyles(dataSource, dataSource.entities.values, {
+          isCesium2D: this.terria.mainViewer.viewerMode === ViewerMode.Cesium2D
+        });
       }
 
       return dataSource;

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -1451,8 +1451,9 @@ function GeoJsonMixin<T extends Constructor<BaseType>>(Base: T) {
 
       this.applyMixedStyle(dataSource);
 
-      if (isRerPoiUrl(this.url) && this.type !== RER_POI_CATALOG_ITEM_TYPE) {
-        applyRerPoiEntityStyles(dataSource);
+   if (isRerPoiUrl(this.url) && this.type !== RER_POI_CATALOG_ITEM_TYPE) {
+        // FIX: Pass the array of entities as the second argument to match the new signature
+        applyRerPoiEntityStyles(dataSource, dataSource.entities.values);
       }
 
       return dataSource;

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -731,6 +731,14 @@ function GeoJsonMixin<T extends Constructor<BaseType>>(Base: T) {
             });
           }
 
+          (dataSource as any)[LEAFLET_CLUSTERING_CONFIG_KEY] = {
+            enabled: clusteringEnabled,
+            pixelRange: clusteringPixelRange,
+            minimumClusterSize: clusteringMinSize,
+            pinSize: clusteringPinSize,
+            pinBackgroundColor: clusteringPinBackgroundColor
+          } as LeafletClusteringConfig;
+
           runInAction(() => {
             this._dataSource = dataSource;
             this._imageryProvider = undefined;
@@ -2746,6 +2754,16 @@ export function parseMarkerSize(sizeString?: string): number | undefined {
   }
   return parseInt(sizeString, 10); // SimpleStyle doesn't allow 'marker-size: 20', but people will do it.
 }
+
+export interface LeafletClusteringConfig {
+  enabled: boolean;
+  pixelRange: number;
+  minimumClusterSize: number;
+  pinSize: number;
+  pinBackgroundColor: string;
+}
+
+export const LEAFLET_CLUSTERING_CONFIG_KEY = "__leafletClusteringConfig__";
 
 function stringifyFeatureProperties(featureProps: JsonObject | undefined) {
   return Object.keys(featureProps ?? {}).reduce<{

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -115,6 +115,11 @@ import SearchableCatalogItemMixin, {
 } from "./SearchableCatalogItemMixin";
 import QueryableCatalogItemMixin from "./QueryableCatalogItemMixin";
 import Constructor from "../Core/Constructor";
+import {
+  applyRerPoiEntityStyles,
+  isRerPoiUrl,
+  RER_POI_CATALOG_ITEM_TYPE
+} from "./RerPoiHelpers";
 
 enum PathTypes {
   noPath = 0,
@@ -223,6 +228,7 @@ class GeoJsonStratum extends LoadableStratum(GeoJsonTraits) {
     // If more than 50% of features have simple style properties - disable table styling
     if (
       this._item.featureCounts.multiPoint > 0 ||
+      this._item.featureCounts.point > 500 ||
       this._item.featureCounts.simpleStyle / this._item.featureCounts.total >=
         0.5
     ) {
@@ -466,7 +472,11 @@ function GeoJsonMixin<T extends Constructor<BaseType>>(Base: T) {
 
     @override
     get mapItems() {
-      if (this.isLoadingMapItems) {
+      if (
+        this.isLoadingMapItems &&
+        !this._dataSource &&
+        !this._imageryProvider
+      ) {
         return [];
       }
       this._dataSource ? (this._dataSource.show = this.show) : null;
@@ -512,6 +522,7 @@ function GeoJsonMixin<T extends Constructor<BaseType>>(Base: T) {
     @computed
     get useTableStylingAndProtomaps() {
       return (
+        !isRerPoiUrl(this.url) &&
         !this.forceCesiumPrimitives &&
         !isDefined(this.czmlTemplate) &&
         // Table styling doesn't support the old GeoJson StyleTraits
@@ -561,6 +572,11 @@ function GeoJsonMixin<T extends Constructor<BaseType>>(Base: T) {
       const czmlTemplate = this.czmlTemplate;
       const filterByProperties = this.filterByProperties;
       const explodeMultiPoints = this.explodeMultiPoints;
+      const clusteringEnabled = this.clustering.enabled;
+      const clusteringPixelRange = this.clustering.pixelRange;
+      const clusteringMinSize = this.clustering.minimumClusterSize;
+      const clusteringPinBackgroundColor = this.clustering.pinBackgroundColor;
+      const clusteringPinSize = this.clustering.pinSize;
 
       let geoJson: FeatureCollectionWithCrs | undefined;
 
@@ -682,29 +698,35 @@ function GeoJsonMixin<T extends Constructor<BaseType>>(Base: T) {
         } else {
           const dataSource = await this.loadGeoJsonDataSource(geoJsonWgs84);
 
-          if (this.clustering.enabled) {
-            const pinBackgroundColor = this.clustering.pinBackgroundColor;
-            const pinSize = this.clustering.pinSize;
-
+          if (clusteringEnabled && !dataSource.clustering.enabled) {
             const pinBuilder = new PinBuilder();
+            const pinColor = Color.fromCssColorString(
+              clusteringPinBackgroundColor
+            );
+            const pinCache = new Map<number, string>();
+
             dataSource.clustering.enabled = true;
-            dataSource.clustering.pixelRange = this.clustering.pixelRange;
-            dataSource.clustering.minimumClusterSize =
-              this.clustering.minimumClusterSize;
+            dataSource.clustering.pixelRange = clusteringPixelRange;
+            dataSource.clustering.minimumClusterSize = clusteringMinSize;
             dataSource.clustering.clusterEvent.addEventListener(function (
               entities,
               cluster
             ) {
               cluster.label.show = false;
               cluster.billboard.verticalOrigin = VerticalOrigin.BOTTOM;
-              cluster.billboard.image = pinBuilder
-                .fromText(
-                  entities.length.toLocaleString(),
-                  Color.fromCssColorString(pinBackgroundColor),
-                  pinSize
-                )
-                .toDataURL();
+              cluster.billboard.disableDepthTestDistance =
+                Number.POSITIVE_INFINITY;
               cluster.billboard.show = true;
+
+              const count = entities.length;
+              let image = pinCache.get(count);
+              if (!image) {
+                image = pinBuilder
+                  .fromText(count.toLocaleString(), pinColor, clusteringPinSize)
+                  .toDataURL();
+                pinCache.set(count, image);
+              }
+              cluster.billboard.image = image;
             });
           }
 
@@ -1428,6 +1450,10 @@ function GeoJsonMixin<T extends Constructor<BaseType>>(Base: T) {
       }
 
       this.applyMixedStyle(dataSource);
+
+      if (isRerPoiUrl(this.url) && this.type !== RER_POI_CATALOG_ITEM_TYPE) {
+        applyRerPoiEntityStyles(dataSource);
+      }
 
       return dataSource;
     }

--- a/lib/ModelMixins/QueryableCatalogItemMixin.ts
+++ b/lib/ModelMixins/QueryableCatalogItemMixin.ts
@@ -117,6 +117,32 @@ function QueryableCatalogItemMixin<T extends Constructor<MixinModel>>(Base: T) {
     }
 
     @action
+    sanitizeQueryValues() {
+      if (!this.queryValues || !this.enumValues || !this.queryProperties)
+        return;
+
+      let changed = false;
+      for (const [name, property] of Object.entries(this.queryProperties)) {
+        if (property.type !== "enum") continue;
+
+        const currentValue = this.queryValues[name]?.[0] ?? "";
+        if (currentValue === "" || currentValue === this.ENUM_ALL_VALUE)
+          continue;
+
+        const available = this.enumValues[name] ?? [];
+        if (!available.includes(currentValue)) {
+          this.queryValues[name] = [""];
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        this.filterData();
+        this.updateEnumValues();
+      }
+    }
+
+    @action
     initQueryValues() {
       if (!this.queryProperties) return;
 

--- a/lib/ModelMixins/RerPoiHelpers.ts
+++ b/lib/ModelMixins/RerPoiHelpers.ts
@@ -1,0 +1,245 @@
+import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import Color from "terriajs-cesium/Source/Core/Color";
+import DistanceDisplayCondition from "terriajs-cesium/Source/Core/DistanceDisplayCondition";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import BillboardGraphics from "terriajs-cesium/Source/DataSources/BillboardGraphics";
+import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantProperty";
+import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
+import HeightReference from "terriajs-cesium/Source/Scene/HeightReference";
+import VerticalOrigin from "terriajs-cesium/Source/Scene/VerticalOrigin";
+import PinBuilder from "terriajs-cesium/Source/Core/PinBuilder";
+import { getMakiIcon } from "../Map/Icons/Maki/MakiIcons";
+import {
+  defaultRerPoiCatalogItemTraits,
+  PoiDomainStyleGroup
+} from "../Traits/TraitsClasses/RerPoiCatalogItemTraits";
+
+export const RER_POI_CATALOG_ITEM_TYPE = "rer-poi";
+export const RER_POI_URL_REGEX =
+  /^https?:\/\/servizigis\.regione\.emilia-romagna\.it\/geoags\/rest\/services\/portale\/rer3d_poi\/MapServer\/0$/i;
+
+export function normalizeRerPoiUrl(url: string | undefined): string {
+  return (url ?? "")
+    .trim()
+    .replace(/[?#].*$/, "")
+    .replace(/\/query\/?$/i, "")
+    .replace(/\/+$/, "");
+}
+
+export function isRerPoiUrl(url: string | undefined): boolean {
+  return RER_POI_URL_REGEX.test(normalizeRerPoiUrl(url));
+}
+
+export interface RerPoiStylingOptions {
+  defaultMarkerColor?: string;
+  markerSize?: number;
+  iconStrokeWidth?: number;
+  iconStrokeColor?: string;
+  poiDomainStyleGroups?: PoiDomainStyleGroup[];
+  scaleField?: string;
+  domainIdField?: string;
+}
+
+const VERTICAL_ORIGIN = new ConstantProperty(VerticalOrigin.BOTTOM);
+const HEIGHT_REFERENCE = new ConstantProperty(HeightReference.CLAMP_TO_GROUND);
+const EYE_OFFSET = new ConstantProperty(new Cartesian3(0, 0, -12));
+const DEPTH_TEST_DISTANCE = new ConstantProperty(Number.POSITIVE_INFINITY);
+
+type PoiDomainStyle = { symbol: string; color?: string };
+
+const MARKER_IMAGE_CACHE = new Map<
+  string,
+  HTMLCanvasElement | Promise<HTMLCanvasElement>
+>();
+const pinBuilder = new PinBuilder();
+
+function getPinImage(
+  iconId: string,
+  color: string,
+  markerSize: number,
+  iconStrokeWidth: number,
+  iconStrokeColor: string
+): HTMLCanvasElement | Promise<HTMLCanvasElement> | undefined {
+  const key = [
+    iconId,
+    color,
+    markerSize,
+    iconStrokeWidth,
+    iconStrokeColor
+  ].join("|");
+
+  const cached = MARKER_IMAGE_CACHE.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const svgUrl = getMakiIcon(
+    iconId,
+    "#ffffff",
+    iconStrokeWidth,
+    iconStrokeColor,
+    24,
+    24
+  );
+
+  if (!svgUrl) {
+    return undefined;
+  }
+
+  const pinColor = Color.fromCssColorString(color);
+  const image = pinBuilder.fromUrl(svgUrl, pinColor, markerSize) as
+    | HTMLCanvasElement
+    | Promise<HTMLCanvasElement>;
+
+  if (image instanceof Promise) {
+    image.then((canvas: HTMLCanvasElement) => {
+      MARKER_IMAGE_CACHE.set(key, canvas);
+    });
+  }
+
+  MARKER_IMAGE_CACHE.set(key, image);
+  return image;
+}
+
+function getVisibilityRange(
+  scaleValue: unknown
+): DistanceDisplayCondition | undefined {
+  const maxDistance = Number(scaleValue);
+  return Number.isFinite(maxDistance)
+    ? new DistanceDisplayCondition(0, maxDistance)
+    : undefined;
+}
+
+function normalizePoiDomainStyleGroup(
+  group: Partial<PoiDomainStyleGroup>
+): PoiDomainStyleGroup {
+  const normalized = new PoiDomainStyleGroup();
+
+  normalized.id = typeof group.id === "string" ? group.id : "";
+  normalized.symbol =
+    typeof group.symbol === "string" && group.symbol.trim()
+      ? group.symbol.trim()
+      : "marker";
+  normalized.color =
+    typeof group.color === "string" && group.color.trim()
+      ? group.color.trim()
+      : undefined;
+  normalized.domainIds = Array.isArray(group.domainIds)
+    ? group.domainIds.map((x: any) => Number(x)).filter(Number.isFinite)
+    : [];
+
+  return normalized;
+}
+
+function getDefaultPoiDomainStyleGroups(): PoiDomainStyleGroup[] {
+  return (defaultRerPoiCatalogItemTraits.poiDomainStyleGroups ?? []).map(
+    normalizePoiDomainStyleGroup
+  );
+}
+
+function buildPoiDomainStyleMap(
+  groups: PoiDomainStyleGroup[]
+): Record<number, PoiDomainStyle> {
+  return groups.reduce<Record<number, PoiDomainStyle>>((acc, group) => {
+    for (const domainId of group.domainIds ?? []) {
+      acc[domainId] = {
+        symbol: group.symbol,
+        color: group.color
+      };
+    }
+    return acc;
+  }, {});
+}
+
+function getRerPoiIconId(symbol: unknown): string {
+  return typeof symbol === "string" && symbol.trim() ? symbol.trim() : "marker";
+}
+
+export function applyRerPoiEntityStyles(
+  dataSource: GeoJsonDataSource,
+  options?: RerPoiStylingOptions
+): void {
+  const defaultMarkerColor =
+    options?.defaultMarkerColor ??
+    defaultRerPoiCatalogItemTraits.defaultMarkerColor;
+  const markerSize =
+    options?.markerSize ?? defaultRerPoiCatalogItemTraits.markerSize;
+  const iconStrokeWidth =
+    options?.iconStrokeWidth ?? defaultRerPoiCatalogItemTraits.iconStrokeWidth;
+  const iconStrokeColor =
+    options?.iconStrokeColor ?? defaultRerPoiCatalogItemTraits.iconStrokeColor;
+  const poiDomainStyleGroups = (
+    options?.poiDomainStyleGroups?.length
+      ? options.poiDomainStyleGroups
+      : getDefaultPoiDomainStyleGroups()
+  ).map(normalizePoiDomainStyleGroup);
+  const scaleField =
+    options?.scaleField ?? defaultRerPoiCatalogItemTraits.scaleField;
+  const domainIdField =
+    options?.domainIdField ?? defaultRerPoiCatalogItemTraits.domainIdField;
+
+  const poiDomainIconMap = buildPoiDomainStyleMap(poiDomainStyleGroups);
+  const entities = dataSource.entities.values;
+
+  const now = JulianDate.now();
+
+  dataSource.entities.suspendEvents();
+  try {
+    for (let i = 0; i < entities.length; i++) {
+      const entity = entities[i];
+      const properties = entity.properties;
+
+      const visibilityRange = getVisibilityRange(
+        properties?.[scaleField]?.getValue(now)
+      );
+      const visibilityProp = visibilityRange
+        ? new ConstantProperty(visibilityRange)
+        : undefined;
+
+      if (entity.position) {
+        const rawDomainValue = properties?.[domainIdField]?.getValue(now);
+        const domainId = Number(rawDomainValue);
+        const mapped = Number.isFinite(domainId)
+          ? poiDomainIconMap[domainId]
+          : undefined;
+
+        const symbol = getRerPoiIconId(mapped?.symbol);
+        const color = mapped?.color ?? defaultMarkerColor;
+
+        const imageResult = getPinImage(
+          symbol,
+          color,
+          markerSize,
+          iconStrokeWidth,
+          iconStrokeColor
+        );
+
+        if (imageResult) {
+          const createBillboard = (img: HTMLCanvasElement) => {
+            entity.billboard = new BillboardGraphics({
+              image: new ConstantProperty(img),
+              verticalOrigin: VERTICAL_ORIGIN,
+              heightReference: HEIGHT_REFERENCE,
+              width: new ConstantProperty(markerSize),
+              height: new ConstantProperty(markerSize),
+              eyeOffset: EYE_OFFSET,
+              distanceDisplayCondition: visibilityProp,
+              disableDepthTestDistance: DEPTH_TEST_DISTANCE
+            });
+            entity.point = undefined;
+          };
+
+          if (imageResult instanceof Promise) {
+            imageResult.then(createBillboard);
+          } else {
+            createBillboard(imageResult);
+          }
+        }
+      }
+
+      entity.label = undefined;
+    }
+  } finally {
+    dataSource.entities.resumeEvents();
+  }
+}

--- a/lib/ModelMixins/RerPoiHelpers.ts
+++ b/lib/ModelMixins/RerPoiHelpers.ts
@@ -354,6 +354,7 @@ export function applyRerPoiEntityStyles(
         if (!dataSource.entities.contains(entity)) return;
 
         entity.billboard = new BillboardGraphics({
+          show: new ConstantProperty(entity.show !== false),
           image: new ConstantProperty(dataUrl),
           verticalOrigin: BILLBOARD_VERTICAL_ORIGIN,
           heightReference: HEIGHT_REFERENCE,

--- a/lib/ModelMixins/RerPoiHelpers.ts
+++ b/lib/ModelMixins/RerPoiHelpers.ts
@@ -1,4 +1,3 @@
-import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Color from "terriajs-cesium/Source/Core/Color";
 import DistanceDisplayCondition from "terriajs-cesium/Source/Core/DistanceDisplayCondition";
@@ -6,9 +5,7 @@ import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import BillboardGraphics from "terriajs-cesium/Source/DataSources/BillboardGraphics";
 import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantProperty";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
-import LabelGraphics from "terriajs-cesium/Source/DataSources/LabelGraphics";
 import HeightReference from "terriajs-cesium/Source/Scene/HeightReference";
-import LabelStyle from "terriajs-cesium/Source/Scene/LabelStyle";
 import VerticalOrigin from "terriajs-cesium/Source/Scene/VerticalOrigin";
 import PinBuilder from "terriajs-cesium/Source/Core/PinBuilder";
 import { getMakiIcon } from "../Map/Icons/Maki/MakiIcons";
@@ -63,127 +60,79 @@ type LabelStyleOptions = {
   labelOutlineColor: string;
 };
 
-// Use base64 Data URLs strings instead of HTMLCanvasElement to prevent browser VRAM eviction (black icons)
-const MARKER_IMAGE_CACHE = new Map<string, string | Promise<string>>();
+// 1. Dual Caching System
+// Cache raw base markers for quick compositing
+const PIN_CANVAS_CACHE = new Map<string, HTMLCanvasElement | Promise<HTMLCanvasElement>>();
+// Cache the final baked data URLs to feed directly to Cesium (prevents browser eviction)
+const COMPOSITE_DATAURL_CACHE = new Map<string, string | Promise<string>>();
+
 const pinBuilder = new PinBuilder();
 
-function getPinImage(
+function getPinCanvas(
   iconId: string,
   color: string,
   markerSize: number,
   iconStrokeWidth: number,
   iconStrokeColor: string
-): string | Promise<string> | undefined {
-  const key = [
-    iconId,
-    color,
-    markerSize,
-    iconStrokeWidth,
-    iconStrokeColor
-  ].join("|");
+): HTMLCanvasElement | Promise<HTMLCanvasElement> | undefined {
+  const key = [iconId, color, markerSize, iconStrokeWidth, iconStrokeColor].join("|");
 
-  const cached = MARKER_IMAGE_CACHE.get(key);
-  if (cached) {
-    return cached;
-  }
+  const cached = PIN_CANVAS_CACHE.get(key);
+  if (cached) return cached;
 
-  const svgUrl = getMakiIcon(
-    iconId,
-    "#ffffff",
-    iconStrokeWidth,
-    iconStrokeColor,
-    24,
-    24
-  );
-
-  if (!svgUrl) {
-    return undefined;
-  }
+  const svgUrl = getMakiIcon(iconId, "#ffffff", iconStrokeWidth, iconStrokeColor, 24, 24);
+  if (!svgUrl) return undefined;
 
   const pinColor = Color.fromCssColorString(color);
-  const image = pinBuilder.fromUrl(svgUrl, pinColor, markerSize) as
-    | HTMLCanvasElement
-    | Promise<HTMLCanvasElement>;
+  const image = pinBuilder.fromUrl(svgUrl, pinColor, markerSize) as HTMLCanvasElement | Promise<HTMLCanvasElement>;
 
   if (image instanceof Promise) {
-    const stringPromise = image.then((canvas: HTMLCanvasElement) => {
-      const dataUrl = canvas.toDataURL();
-      MARKER_IMAGE_CACHE.set(key, dataUrl);
-      return dataUrl;
+    image.then((canvas: HTMLCanvasElement) => {
+      PIN_CANVAS_CACHE.set(key, canvas);
     });
-    MARKER_IMAGE_CACHE.set(key, stringPromise);
-    return stringPromise;
   }
 
-  const dataUrl = image.toDataURL();
-  MARKER_IMAGE_CACHE.set(key, dataUrl);
-  return dataUrl;
+  PIN_CANVAS_CACHE.set(key, image);
+  return image;
 }
 
-function getVisibilityRange(
-  scaleValue: unknown
-): DistanceDisplayCondition | undefined {
-  const maxDistance = Number(scaleValue);
-  return Number.isFinite(maxDistance)
-    ? new DistanceDisplayCondition(0, maxDistance)
-    : undefined;
+// Brought back exactly from your original code
+function measureTextMetrics(
+  ctx: CanvasRenderingContext2D,
+  text: string
+): { width: number; height: number } {
+  const metrics = ctx.measureText(text);
+  const ascent = metrics.actualBoundingBoxAscent ?? 10;
+  const descent = metrics.actualBoundingBoxDescent ?? 3;
+  return {
+    width: metrics.width,
+    height: ascent + descent
+  };
 }
 
-function normalizePoiDomainStyleGroup(
-  group: Partial<PoiDomainStyleGroup>
-): PoiDomainStyleGroup {
-  const normalized = new PoiDomainStyleGroup();
+// Brought back exactly from your original code (stripped of internal caching, as we cache the DataURL higher up)
+function buildCompositeMarkerCanvas(
+  pinImage: HTMLCanvasElement,
+  labelText: string,
+  markerSize: number,
+  labelStyle: LabelStyleOptions
+): HTMLCanvasElement {
+  const { labelTextColor, labelFontSize, labelOutlineWidth, labelOutlineColor } = labelStyle;
 
-  normalized.id = typeof group.id === "string" ? group.id : "";
-  normalized.symbol =
-    typeof group.symbol === "string" && group.symbol.trim()
-      ? group.symbol.trim()
-      : "marker";
-  normalized.color =
-    typeof group.color === "string" && group.color.trim()
-      ? group.color.trim()
-      : undefined;
-  normalized.domainIds = Array.isArray(group.domainIds)
-    ? group.domainIds.map((x) => Number(x)).filter(Number.isFinite)
-    : [];
-
-  return normalized;
-}
-
-function getDefaultPoiDomainStyleGroups(): PoiDomainStyleGroup[] {
-  return (defaultRerPoiCatalogItemTraits.poiDomainStyleGroups ?? []).map(
-    normalizePoiDomainStyleGroup
-  );
-}
-
-function buildPoiDomainStyleMap(
-  groups: PoiDomainStyleGroup[]
-): Record<number, PoiDomainStyle> {
-  return groups.reduce<Record<number, PoiDomainStyle>>((acc, group) => {
-    for (const domainId of group.domainIds ?? []) {
-      acc[domainId] = {
-        symbol: group.symbol,
-        color: group.color
-      };
-    }
-    return acc;
-  }, {});
-}
-
-function getRerPoiIconId(symbol: unknown): string {
-  return typeof symbol === "string" && symbol.trim() ? symbol.trim() : "marker";
-}
-
-// Replaces the heavy text-on-canvas drawing with simple line-breaking for Cesium's native LabelGraphics
-function wrapTextForCesiumLabel(labelText: string, fontSize: number): string {
   const textCanvas = document.createElement("canvas");
   const textCtx = textCanvas.getContext("2d");
-  if (!textCtx) return labelText;
+  if (!textCtx) return pinImage;
 
-  textCtx.font = `${fontSize}px sans-serif`;
+  const font = `${labelFontSize}px sans-serif`;
+  textCtx.font = font;
+
+  const paddingX = 6;
+  const paddingY = 4;
+  const gap = 6;
   const maxTextWidth = 220;
-  const words = labelText.trim().split(/\s+/);
+
   const lines: string[] = [];
+  const words = labelText.trim().split(/\s+/);
   let currentLine = "";
 
   for (const word of words) {
@@ -195,52 +144,116 @@ function wrapTextForCesiumLabel(labelText: string, fontSize: number): string {
       currentLine = testLine;
     }
   }
+
   if (currentLine) {
     lines.push(currentLine);
   }
 
-  return lines.join("\n");
+  if (lines.length === 0) {
+    lines.push(labelText);
+  }
+
+  const lineMetrics = lines.map((line) => measureTextMetrics(textCtx, line));
+  const textWidth = Math.max(...lineMetrics.map((m) => m.width), 0) + paddingX * 2;
+  const textHeight =
+    lineMetrics.reduce((sum, m) => sum + m.height, 0) +
+    paddingY * 2 +
+    Math.max(0, lines.length - 1) * 2;
+
+  const canvasWidth = Math.max(pinImage.width, Math.ceil(textWidth));
+  const canvasHeight = Math.ceil(textHeight) + gap + pinImage.height;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return pinImage;
+
+  ctx.imageSmoothingEnabled = true;
+
+  ctx.font = font;
+  ctx.fillStyle = labelTextColor;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  ctx.strokeStyle = labelOutlineColor;
+  ctx.lineWidth = labelOutlineWidth;
+  ctx.lineJoin = "round";
+  
+  let y = paddingY;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const metrics = lineMetrics[i];
+    ctx.strokeText(line, canvasWidth / 2, y);
+    ctx.fillText(line, canvasWidth / 2, y);
+    y += metrics.height + 2;
+  }
+
+  const pinX = Math.floor((canvasWidth - pinImage.width) / 2);
+  const pinY = Math.ceil(textHeight) + gap;
+  ctx.drawImage(pinImage, pinX, pinY);
+
+  return canvas;
+}
+
+function getVisibilityRange(scaleValue: unknown): DistanceDisplayCondition | undefined {
+  const maxDistance = Number(scaleValue);
+  return Number.isFinite(maxDistance) ? new DistanceDisplayCondition(0, maxDistance) : undefined;
+}
+
+function normalizePoiDomainStyleGroup(group: Partial<PoiDomainStyleGroup>): PoiDomainStyleGroup {
+  const normalized = new PoiDomainStyleGroup();
+  normalized.id = typeof group.id === "string" ? group.id : "";
+  normalized.symbol = typeof group.symbol === "string" && group.symbol.trim() ? group.symbol.trim() : "marker";
+  normalized.color = typeof group.color === "string" && group.color.trim() ? group.color.trim() : undefined;
+  normalized.domainIds = Array.isArray(group.domainIds)
+    ? group.domainIds.map((x) => Number(x)).filter(Number.isFinite)
+    : [];
+  return normalized;
+}
+
+function getDefaultPoiDomainStyleGroups(): PoiDomainStyleGroup[] {
+  return (defaultRerPoiCatalogItemTraits.poiDomainStyleGroups ?? []).map(normalizePoiDomainStyleGroup);
+}
+
+function buildPoiDomainStyleMap(groups: PoiDomainStyleGroup[]): Record<number, PoiDomainStyle> {
+  return groups.reduce<Record<number, PoiDomainStyle>>((acc, group) => {
+    for (const domainId of group.domainIds ?? []) {
+      acc[domainId] = { symbol: group.symbol, color: group.color };
+    }
+    return acc;
+  }, {});
+}
+
+function getRerPoiIconId(symbol: unknown): string {
+  return typeof symbol === "string" && symbol.trim() ? symbol.trim() : "marker";
 }
 
 export function applyRerPoiEntityStyles(
   dataSource: GeoJsonDataSource,
-  entitiesToStyle: any[], // Accepts only the targeted entities to prevent rebuilding the whole list
+  entitiesToStyle: any[], // Target only new entities to prevent massive GPU thrashing
   options?: RerPoiStylingOptions
 ): void {
-  const defaultMarkerColor =
-    options?.defaultMarkerColor ??
-    defaultRerPoiCatalogItemTraits.defaultMarkerColor;
-  const markerSize =
-    options?.markerSize ?? defaultRerPoiCatalogItemTraits.markerSize;
-  const iconStrokeWidth =
-    options?.iconStrokeWidth ?? defaultRerPoiCatalogItemTraits.iconStrokeWidth;
-  const iconStrokeColor =
-    options?.iconStrokeColor ?? defaultRerPoiCatalogItemTraits.iconStrokeColor;
-  const showLabels =
-    options?.showLabels ?? defaultRerPoiCatalogItemTraits.showLabels;
+  const defaultMarkerColor = options?.defaultMarkerColor ?? defaultRerPoiCatalogItemTraits.defaultMarkerColor;
+  const markerSize = options?.markerSize ?? defaultRerPoiCatalogItemTraits.markerSize;
+  const iconStrokeWidth = options?.iconStrokeWidth ?? defaultRerPoiCatalogItemTraits.iconStrokeWidth;
+  const iconStrokeColor = options?.iconStrokeColor ?? defaultRerPoiCatalogItemTraits.iconStrokeColor;
+  const showLabels = options?.showLabels ?? defaultRerPoiCatalogItemTraits.showLabels;
+  
   const labelStyle: LabelStyleOptions = {
-    labelTextColor:
-      options?.labelTextColor ?? defaultRerPoiCatalogItemTraits.labelTextColor,
-    labelFontSize:
-      options?.labelFontSize ?? defaultRerPoiCatalogItemTraits.labelFontSize,
-    labelOutlineWidth:
-      options?.labelOutlineWidth ??
-      defaultRerPoiCatalogItemTraits.labelOutlineWidth,
-    labelOutlineColor:
-      options?.labelOutlineColor ??
-      defaultRerPoiCatalogItemTraits.labelOutlineColor
+    labelTextColor: options?.labelTextColor ?? defaultRerPoiCatalogItemTraits.labelTextColor,
+    labelFontSize: options?.labelFontSize ?? defaultRerPoiCatalogItemTraits.labelFontSize,
+    labelOutlineWidth: options?.labelOutlineWidth ?? defaultRerPoiCatalogItemTraits.labelOutlineWidth,
+    labelOutlineColor: options?.labelOutlineColor ?? defaultRerPoiCatalogItemTraits.labelOutlineColor
   };
+
   const poiDomainStyleGroups = (
-    options?.poiDomainStyleGroups?.length
-      ? options.poiDomainStyleGroups
-      : getDefaultPoiDomainStyleGroups()
+    options?.poiDomainStyleGroups?.length ? options.poiDomainStyleGroups : getDefaultPoiDomainStyleGroups()
   ).map(normalizePoiDomainStyleGroup);
-  const scaleField =
-    options?.scaleField ?? defaultRerPoiCatalogItemTraits.scaleField;
-  const nameField =
-    options?.nameField ?? defaultRerPoiCatalogItemTraits.nameField;
-  const domainIdField =
-    options?.domainIdField ?? defaultRerPoiCatalogItemTraits.domainIdField;
+  
+  const scaleField = options?.scaleField ?? defaultRerPoiCatalogItemTraits.scaleField;
+  const nameField = options?.nameField ?? defaultRerPoiCatalogItemTraits.nameField;
+  const domainIdField = options?.domainIdField ?? defaultRerPoiCatalogItemTraits.domainIdField;
 
   const poiDomainIconMap = buildPoiDomainStyleMap(poiDomainStyleGroups);
   const now = JulianDate.now();
@@ -251,85 +264,75 @@ export function applyRerPoiEntityStyles(
       const entity = entitiesToStyle[i];
       const properties = entity.properties;
 
-      const visibilityRange = getVisibilityRange(
-        properties?.[scaleField]?.getValue(now)
-      );
-      const visibilityProp = visibilityRange
-        ? new ConstantProperty(visibilityRange)
-        : undefined;
+      const visibilityRange = getVisibilityRange(properties?.[scaleField]?.getValue(now));
+      const visibilityProp = visibilityRange ? new ConstantProperty(visibilityRange) : undefined;
 
-      if (entity.position) {
-        const rawDomainValue = properties?.[domainIdField]?.getValue(now);
-        const domainId = Number(rawDomainValue);
-        const mapped = Number.isFinite(domainId)
-          ? poiDomainIconMap[domainId]
-          : undefined;
+      if (!entity.position) continue;
 
-        const symbol = getRerPoiIconId(mapped?.symbol);
-        const color = mapped?.color ?? defaultMarkerColor;
+      const rawDomainValue = properties?.[domainIdField]?.getValue(now);
+      const domainId = Number(rawDomainValue);
+      const mapped = Number.isFinite(domainId) ? poiDomainIconMap[domainId] : undefined;
 
-        const imageResult = getPinImage(
-          symbol,
-          color,
-          markerSize,
-          iconStrokeWidth,
-          iconStrokeColor
-        );
+      const symbol = getRerPoiIconId(mapped?.symbol);
+      const color = mapped?.color ?? defaultMarkerColor;
 
-        const rawName = properties?.[nameField]?.getValue(now);
-        const name =
-          isDefined(rawName) && String(rawName).trim().length > 0
-            ? String(rawName).trim()
-            : undefined;
+      const rawName = properties?.[nameField]?.getValue(now);
+      const name = isDefined(rawName) && String(rawName).trim().length > 0 ? String(rawName).trim() : undefined;
 
-        if (imageResult) {
-          const createVisuals = (imgDataUrl: string) => {
-            // Anti-Ghosting Check: If the user toggled the filter rapidly, 
-            // this entity might have been removed before the Promise resolved.
-            if (!dataSource.entities.contains(entity)) return;
+      // Uniquely identify the FINAL baked image (including the text)
+      const finalCacheKey = [symbol, color, markerSize, iconStrokeWidth, iconStrokeColor, name, showLabels].join("|");
 
-            entity.billboard = new BillboardGraphics({
-              image: new ConstantProperty(imgDataUrl),
-              verticalOrigin: BILLBOARD_VERTICAL_ORIGIN,
-              heightReference: HEIGHT_REFERENCE,
-              eyeOffset: EYE_OFFSET,
-              distanceDisplayCondition: visibilityProp,
-              disableDepthTestDistance: DEPTH_TEST_DISTANCE
-            });
+      const createVisuals = (dataUrl: string) => {
+        // Anti-Ghosting Check: Cancel render if the entity was destroyed mid-generation
+        if (!dataSource.entities.contains(entity)) return;
 
-            if (name && showLabels) {
-              const multiLineText = wrapTextForCesiumLabel(
-                name,
-                labelStyle.labelFontSize
-              );
+        entity.billboard = new BillboardGraphics({
+          image: new ConstantProperty(dataUrl), // Applying the stable base-64 string
+          verticalOrigin: BILLBOARD_VERTICAL_ORIGIN,
+          heightReference: HEIGHT_REFERENCE,
+          eyeOffset: EYE_OFFSET,
+          distanceDisplayCondition: visibilityProp,
+          disableDepthTestDistance: DEPTH_TEST_DISTANCE
+        });
 
-              entity.label = new LabelGraphics({
-                text: new ConstantProperty(multiLineText),
-                font: new ConstantProperty(`${labelStyle.labelFontSize}px sans-serif`),
-                fillColor: new ConstantProperty(Color.fromCssColorString(labelStyle.labelTextColor)),
-                outlineColor: new ConstantProperty(Color.fromCssColorString(labelStyle.labelOutlineColor)),
-                outlineWidth: new ConstantProperty(labelStyle.labelOutlineWidth),
-                style: new ConstantProperty(LabelStyle.FILL_AND_OUTLINE),
-                verticalOrigin: new ConstantProperty(VerticalOrigin.BOTTOM),
-                pixelOffset: new ConstantProperty(new Cartesian2(0, -markerSize - 6)),
-                heightReference: HEIGHT_REFERENCE,
-                eyeOffset: EYE_OFFSET,
-                distanceDisplayCondition: visibilityProp,
-                disableDepthTestDistance: DEPTH_TEST_DISTANCE
-              });
-            } else {
-              entity.label = undefined;
-            }
+        entity.label = undefined;
+        entity.point = undefined;
+      };
 
-            entity.point = undefined;
-          };
-
-          if (imageResult instanceof Promise) {
-            imageResult.then(createVisuals);
-          } else {
-            createVisuals(imageResult);
-          }
+      // 1. Check if we already baked this exact marker + text combo
+      const cachedDataUrl = COMPOSITE_DATAURL_CACHE.get(finalCacheKey);
+      if (cachedDataUrl) {
+        if (cachedDataUrl instanceof Promise) {
+          cachedDataUrl.then(createVisuals);
+        } else {
+          createVisuals(cachedDataUrl);
         }
+        continue;
+      }
+
+      // 2. If not baked, get the base Pin canvas first
+      const pinCanvasResult = getPinCanvas(symbol, color, markerSize, iconStrokeWidth, iconStrokeColor);
+      if (!pinCanvasResult) continue;
+
+      // 3. Bake the final canvas and convert to Data URL immediately
+      const generateFinalDataUrl = (pinCanvas: HTMLCanvasElement): string => {
+        const finalCanvas = (name && showLabels)
+            ? buildCompositeMarkerCanvas(pinCanvas, name, markerSize, labelStyle)
+            : pinCanvas;
+            
+        const dataUrl = finalCanvas.toDataURL(); // Prevents browser VRAM eviction
+        COMPOSITE_DATAURL_CACHE.set(finalCacheKey, dataUrl); // Store concrete string over the promise
+        return dataUrl;
+      };
+
+      // 4. Handle Promise resolution if the base Pin is still downloading
+      if (pinCanvasResult instanceof Promise) {
+         const dataUrlPromise = pinCanvasResult.then(generateFinalDataUrl);
+         COMPOSITE_DATAURL_CACHE.set(finalCacheKey, dataUrlPromise);
+         dataUrlPromise.then(createVisuals);
+      } else {
+         const dataUrl = generateFinalDataUrl(pinCanvasResult);
+         createVisuals(dataUrl);
       }
     }
   } finally {

--- a/lib/ModelMixins/RerPoiHelpers.ts
+++ b/lib/ModelMixins/RerPoiHelpers.ts
@@ -1,3 +1,4 @@
+import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Color from "terriajs-cesium/Source/Core/Color";
 import DistanceDisplayCondition from "terriajs-cesium/Source/Core/DistanceDisplayCondition";
@@ -5,7 +6,9 @@ import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import BillboardGraphics from "terriajs-cesium/Source/DataSources/BillboardGraphics";
 import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantProperty";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
+import LabelGraphics from "terriajs-cesium/Source/DataSources/LabelGraphics";
 import HeightReference from "terriajs-cesium/Source/Scene/HeightReference";
+import LabelStyle from "terriajs-cesium/Source/Scene/LabelStyle";
 import VerticalOrigin from "terriajs-cesium/Source/Scene/VerticalOrigin";
 import PinBuilder from "terriajs-cesium/Source/Core/PinBuilder";
 import { getMakiIcon } from "../Map/Icons/Maki/MakiIcons";
@@ -53,21 +56,15 @@ const EYE_OFFSET = new ConstantProperty(new Cartesian3(0, 0, -12));
 const DEPTH_TEST_DISTANCE = new ConstantProperty(Number.POSITIVE_INFINITY);
 
 type PoiDomainStyle = { symbol: string; color?: string };
-type LabelStyle = {
+type LabelStyleOptions = {
   labelTextColor: string;
   labelFontSize: number;
   labelOutlineWidth: number;
   labelOutlineColor: string;
 };
 
-const MARKER_IMAGE_CACHE = new Map<
-  string,
-  HTMLCanvasElement | Promise<HTMLCanvasElement>
->();
-const COMPOSITE_IMAGE_CACHE = new Map<
-  string,
-  HTMLCanvasElement | Promise<HTMLCanvasElement>
->();
+// Use base64 Data URLs strings instead of HTMLCanvasElement to prevent browser VRAM eviction (black icons)
+const MARKER_IMAGE_CACHE = new Map<string, string | Promise<string>>();
 const pinBuilder = new PinBuilder();
 
 function getPinImage(
@@ -76,7 +73,7 @@ function getPinImage(
   markerSize: number,
   iconStrokeWidth: number,
   iconStrokeColor: string
-): HTMLCanvasElement | Promise<HTMLCanvasElement> | undefined {
+): string | Promise<string> | undefined {
   const key = [
     iconId,
     color,
@@ -109,13 +106,18 @@ function getPinImage(
     | Promise<HTMLCanvasElement>;
 
   if (image instanceof Promise) {
-    image.then((canvas: HTMLCanvasElement) => {
-      MARKER_IMAGE_CACHE.set(key, canvas);
+    const stringPromise = image.then((canvas: HTMLCanvasElement) => {
+      const dataUrl = canvas.toDataURL();
+      MARKER_IMAGE_CACHE.set(key, dataUrl);
+      return dataUrl;
     });
+    MARKER_IMAGE_CACHE.set(key, stringPromise);
+    return stringPromise;
   }
 
-  MARKER_IMAGE_CACHE.set(key, image);
-  return image;
+  const dataUrl = image.toDataURL();
+  MARKER_IMAGE_CACHE.set(key, dataUrl);
+  return dataUrl;
 }
 
 function getVisibilityRange(
@@ -172,63 +174,16 @@ function getRerPoiIconId(symbol: unknown): string {
   return typeof symbol === "string" && symbol.trim() ? symbol.trim() : "marker";
 }
 
-function measureTextMetrics(
-  ctx: CanvasRenderingContext2D,
-  text: string
-): { width: number; height: number } {
-  const metrics = ctx.measureText(text);
-  const ascent = metrics.actualBoundingBoxAscent ?? 10;
-  const descent = metrics.actualBoundingBoxDescent ?? 3;
-  return {
-    width: metrics.width,
-    height: ascent + descent
-  };
-}
-
-function buildCompositeMarkerImage(
-  pinImage: HTMLCanvasElement,
-  labelText: string,
-  markerSize: number,
-  labelStyle: LabelStyle
-): HTMLCanvasElement {
-  const {
-    labelTextColor,
-    labelFontSize,
-    labelOutlineWidth,
-    labelOutlineColor
-  } = labelStyle;
-  const cacheKey = [
-    pinImage.width,
-    pinImage.height,
-    labelText,
-    markerSize,
-    labelTextColor,
-    labelFontSize,
-    labelOutlineWidth,
-    labelOutlineColor
-  ].join("|");
-
-  const cached = COMPOSITE_IMAGE_CACHE.get(cacheKey);
-  if (cached instanceof HTMLCanvasElement) {
-    return cached;
-  }
-
+// Replaces the heavy text-on-canvas drawing with simple line-breaking for Cesium's native LabelGraphics
+function wrapTextForCesiumLabel(labelText: string, fontSize: number): string {
   const textCanvas = document.createElement("canvas");
   const textCtx = textCanvas.getContext("2d");
-  if (!textCtx) {
-    return pinImage;
-  }
+  if (!textCtx) return labelText;
 
-  const font = `${labelFontSize}px sans-serif`;
-  textCtx.font = font;
-
-  const paddingX = 6;
-  const paddingY = 4;
-  const gap = 6;
+  textCtx.font = `${fontSize}px sans-serif`;
   const maxTextWidth = 220;
-
-  const lines: string[] = [];
   const words = labelText.trim().split(/\s+/);
+  const lines: string[] = [];
   let currentLine = "";
 
   for (const word of words) {
@@ -240,69 +195,16 @@ function buildCompositeMarkerImage(
       currentLine = testLine;
     }
   }
-
   if (currentLine) {
     lines.push(currentLine);
   }
 
-  if (lines.length === 0) {
-    lines.push(labelText);
-  }
-
-  const lineMetrics = lines.map((line) => measureTextMetrics(textCtx, line));
-  const textWidth =
-    Math.max(...lineMetrics.map((m) => m.width), 0) + paddingX * 2;
-  const textHeight =
-    lineMetrics.reduce((sum, m) => sum + m.height, 0) +
-    paddingY * 2 +
-    Math.max(0, lines.length - 1) * 2;
-
-  const canvasWidth = Math.max(pinImage.width, Math.ceil(textWidth));
-  const canvasHeight = Math.ceil(textHeight) + gap + pinImage.height;
-
-  const canvas = document.createElement("canvas");
-  canvas.width = canvasWidth;
-  canvas.height = canvasHeight;
-
-  const ctx = canvas.getContext("2d");
-  if (!ctx) {
-    return pinImage;
-  }
-
-  ctx.imageSmoothingEnabled = true;
-
-  // Draw text at the top.
-  ctx.font = font;
-  ctx.fillStyle = labelTextColor;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "top";
-
-  // Optional outline for readability without a background box.
-  ctx.strokeStyle = labelOutlineColor;
-  ctx.lineWidth = labelOutlineWidth;
-  ctx.lineJoin = "round";
-  let y = paddingY;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const metrics = lineMetrics[i];
-
-    ctx.strokeText(line, canvasWidth / 2, y);
-    ctx.fillText(line, canvasWidth / 2, y);
-
-    y += metrics.height + 2;
-  }
-
-  // Draw the pin below the text.
-  const pinX = Math.floor((canvasWidth - pinImage.width) / 2);
-  const pinY = Math.ceil(textHeight) + gap;
-  ctx.drawImage(pinImage, pinX, pinY);
-
-  COMPOSITE_IMAGE_CACHE.set(cacheKey, canvas);
-  return canvas;
+  return lines.join("\n");
 }
 
 export function applyRerPoiEntityStyles(
   dataSource: GeoJsonDataSource,
+  entitiesToStyle: any[], // Accepts only the targeted entities to prevent rebuilding the whole list
   options?: RerPoiStylingOptions
 ): void {
   const defaultMarkerColor =
@@ -316,7 +218,7 @@ export function applyRerPoiEntityStyles(
     options?.iconStrokeColor ?? defaultRerPoiCatalogItemTraits.iconStrokeColor;
   const showLabels =
     options?.showLabels ?? defaultRerPoiCatalogItemTraits.showLabels;
-  const labelStyle: LabelStyle = {
+  const labelStyle: LabelStyleOptions = {
     labelTextColor:
       options?.labelTextColor ?? defaultRerPoiCatalogItemTraits.labelTextColor,
     labelFontSize:
@@ -341,13 +243,12 @@ export function applyRerPoiEntityStyles(
     options?.domainIdField ?? defaultRerPoiCatalogItemTraits.domainIdField;
 
   const poiDomainIconMap = buildPoiDomainStyleMap(poiDomainStyleGroups);
-  const entities = dataSource.entities.values;
   const now = JulianDate.now();
 
   dataSource.entities.suspendEvents();
   try {
-    for (let i = 0; i < entities.length; i++) {
-      const entity = entities[i];
+    for (let i = 0; i < entitiesToStyle.length; i++) {
+      const entity = entitiesToStyle[i];
       const properties = entity.properties;
 
       const visibilityRange = getVisibilityRange(
@@ -382,14 +283,13 @@ export function applyRerPoiEntityStyles(
             : undefined;
 
         if (imageResult) {
-          const createBillboard = (img: HTMLCanvasElement) => {
-            const finalImage =
-              name && showLabels
-                ? buildCompositeMarkerImage(img, name, markerSize, labelStyle)
-                : img;
+          const createVisuals = (imgDataUrl: string) => {
+            // Anti-Ghosting Check: If the user toggled the filter rapidly, 
+            // this entity might have been removed before the Promise resolved.
+            if (!dataSource.entities.contains(entity)) return;
 
             entity.billboard = new BillboardGraphics({
-              image: new ConstantProperty(finalImage),
+              image: new ConstantProperty(imgDataUrl),
               verticalOrigin: BILLBOARD_VERTICAL_ORIGIN,
               heightReference: HEIGHT_REFERENCE,
               eyeOffset: EYE_OFFSET,
@@ -397,14 +297,37 @@ export function applyRerPoiEntityStyles(
               disableDepthTestDistance: DEPTH_TEST_DISTANCE
             });
 
-            entity.label = undefined;
+            if (name && showLabels) {
+              const multiLineText = wrapTextForCesiumLabel(
+                name,
+                labelStyle.labelFontSize
+              );
+
+              entity.label = new LabelGraphics({
+                text: new ConstantProperty(multiLineText),
+                font: new ConstantProperty(`${labelStyle.labelFontSize}px sans-serif`),
+                fillColor: new ConstantProperty(Color.fromCssColorString(labelStyle.labelTextColor)),
+                outlineColor: new ConstantProperty(Color.fromCssColorString(labelStyle.labelOutlineColor)),
+                outlineWidth: new ConstantProperty(labelStyle.labelOutlineWidth),
+                style: new ConstantProperty(LabelStyle.FILL_AND_OUTLINE),
+                verticalOrigin: new ConstantProperty(VerticalOrigin.BOTTOM),
+                pixelOffset: new ConstantProperty(new Cartesian2(0, -markerSize - 6)),
+                heightReference: HEIGHT_REFERENCE,
+                eyeOffset: EYE_OFFSET,
+                distanceDisplayCondition: visibilityProp,
+                disableDepthTestDistance: DEPTH_TEST_DISTANCE
+              });
+            } else {
+              entity.label = undefined;
+            }
+
             entity.point = undefined;
           };
 
           if (imageResult instanceof Promise) {
-            imageResult.then(createBillboard);
+            imageResult.then(createVisuals);
           } else {
-            createBillboard(imageResult);
+            createVisuals(imageResult);
           }
         }
       }

--- a/lib/ModelMixins/RerPoiHelpers.ts
+++ b/lib/ModelMixins/RerPoiHelpers.ts
@@ -13,6 +13,7 @@ import {
   defaultRerPoiCatalogItemTraits,
   PoiDomainStyleGroup
 } from "../Traits/TraitsClasses/RerPoiCatalogItemTraits";
+import isDefined from "../Core/isDefined";
 
 export const RER_POI_CATALOG_ITEM_TYPE = "rer-poi";
 export const RER_POI_URL_REGEX =
@@ -35,19 +36,35 @@ export interface RerPoiStylingOptions {
   markerSize?: number;
   iconStrokeWidth?: number;
   iconStrokeColor?: string;
+  showLabels?: boolean;
+  labelTextColor?: string;
+  labelFontSize?: number;
+  labelOutlineWidth?: number;
+  labelOutlineColor?: string;
   poiDomainStyleGroups?: PoiDomainStyleGroup[];
   scaleField?: string;
   domainIdField?: string;
+  nameField?: string;
 }
 
-const VERTICAL_ORIGIN = new ConstantProperty(VerticalOrigin.BOTTOM);
+const BILLBOARD_VERTICAL_ORIGIN = new ConstantProperty(VerticalOrigin.BOTTOM);
 const HEIGHT_REFERENCE = new ConstantProperty(HeightReference.CLAMP_TO_GROUND);
 const EYE_OFFSET = new ConstantProperty(new Cartesian3(0, 0, -12));
 const DEPTH_TEST_DISTANCE = new ConstantProperty(Number.POSITIVE_INFINITY);
 
 type PoiDomainStyle = { symbol: string; color?: string };
+type LabelStyle = {
+  labelTextColor: string;
+  labelFontSize: number;
+  labelOutlineWidth: number;
+  labelOutlineColor: string;
+};
 
 const MARKER_IMAGE_CACHE = new Map<
+  string,
+  HTMLCanvasElement | Promise<HTMLCanvasElement>
+>();
+const COMPOSITE_IMAGE_CACHE = new Map<
   string,
   HTMLCanvasElement | Promise<HTMLCanvasElement>
 >();
@@ -125,7 +142,7 @@ function normalizePoiDomainStyleGroup(
       ? group.color.trim()
       : undefined;
   normalized.domainIds = Array.isArray(group.domainIds)
-    ? group.domainIds.map((x: any) => Number(x)).filter(Number.isFinite)
+    ? group.domainIds.map((x) => Number(x)).filter(Number.isFinite)
     : [];
 
   return normalized;
@@ -155,6 +172,135 @@ function getRerPoiIconId(symbol: unknown): string {
   return typeof symbol === "string" && symbol.trim() ? symbol.trim() : "marker";
 }
 
+function measureTextMetrics(
+  ctx: CanvasRenderingContext2D,
+  text: string
+): { width: number; height: number } {
+  const metrics = ctx.measureText(text);
+  const ascent = metrics.actualBoundingBoxAscent ?? 10;
+  const descent = metrics.actualBoundingBoxDescent ?? 3;
+  return {
+    width: metrics.width,
+    height: ascent + descent
+  };
+}
+
+function buildCompositeMarkerImage(
+  pinImage: HTMLCanvasElement,
+  labelText: string,
+  markerSize: number,
+  labelStyle: LabelStyle
+): HTMLCanvasElement {
+  const {
+    labelTextColor,
+    labelFontSize,
+    labelOutlineWidth,
+    labelOutlineColor
+  } = labelStyle;
+  const cacheKey = [
+    pinImage.width,
+    pinImage.height,
+    labelText,
+    markerSize,
+    labelTextColor,
+    labelFontSize,
+    labelOutlineWidth,
+    labelOutlineColor
+  ].join("|");
+
+  const cached = COMPOSITE_IMAGE_CACHE.get(cacheKey);
+  if (cached instanceof HTMLCanvasElement) {
+    return cached;
+  }
+
+  const textCanvas = document.createElement("canvas");
+  const textCtx = textCanvas.getContext("2d");
+  if (!textCtx) {
+    return pinImage;
+  }
+
+  const font = `${labelFontSize}px sans-serif`;
+  textCtx.font = font;
+
+  const paddingX = 6;
+  const paddingY = 4;
+  const gap = 6;
+  const maxTextWidth = 220;
+
+  const lines: string[] = [];
+  const words = labelText.trim().split(/\s+/);
+  let currentLine = "";
+
+  for (const word of words) {
+    const testLine = currentLine ? `${currentLine} ${word}` : word;
+    if (textCtx.measureText(testLine).width > maxTextWidth && currentLine) {
+      lines.push(currentLine);
+      currentLine = word;
+    } else {
+      currentLine = testLine;
+    }
+  }
+
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+
+  if (lines.length === 0) {
+    lines.push(labelText);
+  }
+
+  const lineMetrics = lines.map((line) => measureTextMetrics(textCtx, line));
+  const textWidth =
+    Math.max(...lineMetrics.map((m) => m.width), 0) + paddingX * 2;
+  const textHeight =
+    lineMetrics.reduce((sum, m) => sum + m.height, 0) +
+    paddingY * 2 +
+    Math.max(0, lines.length - 1) * 2;
+
+  const canvasWidth = Math.max(pinImage.width, Math.ceil(textWidth));
+  const canvasHeight = Math.ceil(textHeight) + gap + pinImage.height;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return pinImage;
+  }
+
+  ctx.imageSmoothingEnabled = true;
+
+  // Draw text at the top.
+  ctx.font = font;
+  ctx.fillStyle = labelTextColor;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+
+  // Optional outline for readability without a background box.
+  ctx.strokeStyle = labelOutlineColor;
+  ctx.lineWidth = labelOutlineWidth;
+  ctx.lineJoin = "round";
+  let y = paddingY;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const metrics = lineMetrics[i];
+
+    ctx.strokeText(line, canvasWidth / 2, y);
+    ctx.fillText(line, canvasWidth / 2, y);
+
+    y += metrics.height + 2;
+  }
+
+  // Draw the pin below the text.
+  const pinX = Math.floor((canvasWidth - pinImage.width) / 2);
+  const pinY = Math.ceil(textHeight) + gap;
+  ctx.drawImage(pinImage, pinX, pinY);
+
+  COMPOSITE_IMAGE_CACHE.set(cacheKey, canvas);
+  return canvas;
+}
+
 export function applyRerPoiEntityStyles(
   dataSource: GeoJsonDataSource,
   options?: RerPoiStylingOptions
@@ -168,6 +314,20 @@ export function applyRerPoiEntityStyles(
     options?.iconStrokeWidth ?? defaultRerPoiCatalogItemTraits.iconStrokeWidth;
   const iconStrokeColor =
     options?.iconStrokeColor ?? defaultRerPoiCatalogItemTraits.iconStrokeColor;
+  const showLabels =
+    options?.showLabels ?? defaultRerPoiCatalogItemTraits.showLabels;
+  const labelStyle: LabelStyle = {
+    labelTextColor:
+      options?.labelTextColor ?? defaultRerPoiCatalogItemTraits.labelTextColor,
+    labelFontSize:
+      options?.labelFontSize ?? defaultRerPoiCatalogItemTraits.labelFontSize,
+    labelOutlineWidth:
+      options?.labelOutlineWidth ??
+      defaultRerPoiCatalogItemTraits.labelOutlineWidth,
+    labelOutlineColor:
+      options?.labelOutlineColor ??
+      defaultRerPoiCatalogItemTraits.labelOutlineColor
+  };
   const poiDomainStyleGroups = (
     options?.poiDomainStyleGroups?.length
       ? options.poiDomainStyleGroups
@@ -175,12 +335,13 @@ export function applyRerPoiEntityStyles(
   ).map(normalizePoiDomainStyleGroup);
   const scaleField =
     options?.scaleField ?? defaultRerPoiCatalogItemTraits.scaleField;
+  const nameField =
+    options?.nameField ?? defaultRerPoiCatalogItemTraits.nameField;
   const domainIdField =
     options?.domainIdField ?? defaultRerPoiCatalogItemTraits.domainIdField;
 
   const poiDomainIconMap = buildPoiDomainStyleMap(poiDomainStyleGroups);
   const entities = dataSource.entities.values;
-
   const now = JulianDate.now();
 
   dataSource.entities.suspendEvents();
@@ -214,18 +375,29 @@ export function applyRerPoiEntityStyles(
           iconStrokeColor
         );
 
+        const rawName = properties?.[nameField]?.getValue(now);
+        const name =
+          isDefined(rawName) && String(rawName).trim().length > 0
+            ? String(rawName).trim()
+            : undefined;
+
         if (imageResult) {
           const createBillboard = (img: HTMLCanvasElement) => {
+            const finalImage =
+              name && showLabels
+                ? buildCompositeMarkerImage(img, name, markerSize, labelStyle)
+                : img;
+
             entity.billboard = new BillboardGraphics({
-              image: new ConstantProperty(img),
-              verticalOrigin: VERTICAL_ORIGIN,
+              image: new ConstantProperty(finalImage),
+              verticalOrigin: BILLBOARD_VERTICAL_ORIGIN,
               heightReference: HEIGHT_REFERENCE,
-              width: new ConstantProperty(markerSize),
-              height: new ConstantProperty(markerSize),
               eyeOffset: EYE_OFFSET,
               distanceDisplayCondition: visibilityProp,
               disableDepthTestDistance: DEPTH_TEST_DISTANCE
             });
+
+            entity.label = undefined;
             entity.point = undefined;
           };
 
@@ -236,8 +408,6 @@ export function applyRerPoiEntityStyles(
           }
         }
       }
-
-      entity.label = undefined;
     }
   } finally {
     dataSource.entities.resumeEvents();

--- a/lib/ModelMixins/RerPoiHelpers.ts
+++ b/lib/ModelMixins/RerPoiHelpers.ts
@@ -32,6 +32,7 @@ export function isRerPoiUrl(url: string | undefined): boolean {
 }
 
 export interface RerPoiStylingOptions {
+  isCesium2D?: boolean;
   defaultMarkerColor?: string;
   markerSize?: number;
   iconStrokeWidth?: number;
@@ -48,8 +49,6 @@ export interface RerPoiStylingOptions {
 }
 
 const BILLBOARD_VERTICAL_ORIGIN = new ConstantProperty(VerticalOrigin.BOTTOM);
-const HEIGHT_REFERENCE = new ConstantProperty(HeightReference.CLAMP_TO_GROUND);
-const EYE_OFFSET = new ConstantProperty(new Cartesian3(0, 0, -12));
 const DEPTH_TEST_DISTANCE = new ConstantProperty(Number.POSITIVE_INFINITY);
 
 type PoiDomainStyle = { symbol: string; color?: string };
@@ -269,6 +268,14 @@ export function applyRerPoiEntityStyles(
   entitiesToStyle: any[],
   options?: RerPoiStylingOptions
 ): void {
+  const isCesium2D = options?.isCesium2D ?? false;
+  const heightReferenceProp = new ConstantProperty(
+    isCesium2D ? HeightReference.NONE : HeightReference.CLAMP_TO_GROUND
+  );
+  const eyeOffsetProp = new ConstantProperty(
+    isCesium2D ? Cartesian3.ZERO : new Cartesian3(0, 0, -12)
+  );
+
   const defaultMarkerColor =
     options?.defaultMarkerColor ??
     defaultRerPoiCatalogItemTraits.defaultMarkerColor;
@@ -357,8 +364,8 @@ export function applyRerPoiEntityStyles(
           show: new ConstantProperty(entity.show !== false),
           image: new ConstantProperty(dataUrl),
           verticalOrigin: BILLBOARD_VERTICAL_ORIGIN,
-          heightReference: HEIGHT_REFERENCE,
-          eyeOffset: EYE_OFFSET,
+          heightReference: heightReferenceProp,
+          eyeOffset: eyeOffsetProp,
           distanceDisplayCondition: visibilityProp,
           disableDepthTestDistance: DEPTH_TEST_DISTANCE
         });

--- a/lib/Models/Catalog/Esri/ArcGisFeatureServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisFeatureServerCatalogItem.ts
@@ -156,6 +156,7 @@ interface FeatureServer {
   advancedQueryCapabilities?: {
     supportsPagination: boolean;
   };
+  objectIdField?: string;
 }
 
 interface SpatialReference {
@@ -299,6 +300,10 @@ class FeatureServerStratum extends LoadableStratum(
     }
 
     return !!this._featureServer.advancedQueryCapabilities.supportsPagination;
+  }
+
+  get objectIdField(): string | undefined {
+    return this._featureServer?.objectIdField;
   }
 
   @computed get activeStyle() {
@@ -463,7 +468,7 @@ StratumOrder.addLoadStratum(FeatureServerStratum.stratumName);
 export default class ArcGisFeatureServerCatalogItem extends GeoJsonMixin(
   CreateModel(ArcGisFeatureServerCatalogItemTraits)
 ) {
-  static readonly type = "esri-featureServer";
+  static readonly type: string = "esri-featureServer";
 
   constructor(...args: ModelConstructorParameters) {
     super(...args);
@@ -562,6 +567,13 @@ export default class ArcGisFeatureServerCatalogItem extends GeoJsonMixin(
       FeatureServerStratum.stratumName
     ) as FeatureServerStratum;
     return isDefined(stratum) ? stratum.featureServerData : undefined;
+  }
+
+  get objectIdField(): string {
+    const stratum = this.strata.get(
+      FeatureServerStratum.stratumName
+    ) as FeatureServerStratum;
+    return stratum?.objectIdField ?? "OBJECTID";
   }
 
   /**

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -10,6 +10,7 @@ import {
   makeObservable
 } from "mobx";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
@@ -33,6 +34,9 @@ import {
 import RerPoiCatalogItemTraits, {
   defaultRerPoiCatalogItemTraits
 } from "../../../Traits/TraitsClasses/RerPoiCatalogItemTraits";
+
+import Color from "terriajs-cesium/Source/Core/Color";
+import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
 
 interface EsriJsonQueryOptions {
   resultOffset?: number;
@@ -79,6 +83,8 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   private liveEntityByObjectId = new Map<string, any>();
   private isFirstDynamicLoad = true;
 
+  @observable private debugDataSource: CustomDataSource | undefined;
+
   private readonly onDynamicViewportChanged = () => {
     const isPastLimit = this.isCameraPastTiltLimit();
     runInAction(() => {
@@ -112,6 +118,15 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     onBecomeUnobserved(this, "mapItems", () =>
       this.stopDynamicViewportRequests()
     );
+  }
+
+  @override
+  get mapItems() {
+    const items = super.mapItems.slice();
+    if (this.debugDataSource) {
+      items.push(this.debugDataSource);
+    }
+    return items;
   }
 
   get type(): string {
@@ -196,12 +211,17 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       this.dynamicReloadTimer = undefined;
     }
 
+    runInAction(() => {
+      this.debugDataSource = undefined;
+    });
+
     this.dynamicReloadQueued = false;
     this.dynamicReloadInProgress = false;
     this.managedDataSource = undefined;
     this.liveEntityByObjectId.clear();
     this.isFirstDynamicLoad = true;
   }
+
   private attachCurrentViewerListener() {
     this.detachCurrentViewerListener();
     const cesium = this.terria.cesium;
@@ -343,14 +363,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       if (isVisible) visiblePoiCount += 1;
     }
 
-    console.log("[RerPoiCatalogItem] POI debug", {
-      cachedPoiCount: this.liveEntityByObjectId.size,
-      visiblePoiCount,
-      totalPoiCount,
-      cameraHeight: this.getCurrentCameraHeight(),
-      minLevelId,
-      maxLevelId
-    });
     this.numberOfTotalElements = totalPoiCount;
     this.numberOfVisibleElements = visiblePoiCount;
 
@@ -726,6 +738,119 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     return undefined;
   }
 
+  // --- NEW CORE LOGIC: Dynamically calculate accurate rectangle based on literal screen pixels ---
+  private getScreenBoundingBox(): Rectangle {
+    const currentView = this.terria.currentViewer.getCurrentCameraView();
+    const cesium = this.terria.cesium;
+    if (!cesium) return currentView.rectangle;
+
+    const scene = cesium.scene;
+    const camera = scene.camera;
+    const canvas = scene.canvas;
+    const ellipsoid = scene.globe.ellipsoid;
+
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+
+    // Sample a 3x3 grid across the screen to accurately trace the visible Earth surface
+    const screenPoints = [
+      new Cartesian2(0, 0),
+      new Cartesian2(w / 2, 0),
+      new Cartesian2(w, 0),
+      new Cartesian2(0, h / 2),
+      new Cartesian2(w / 2, h / 2),
+      new Cartesian2(w, h / 2),
+      new Cartesian2(0, h),
+      new Cartesian2(w / 2, h),
+      new Cartesian2(w, h)
+    ];
+
+    let minLon = Number.POSITIVE_INFINITY;
+    let maxLon = Number.NEGATIVE_INFINITY;
+    let minLat = Number.POSITIVE_INFINITY;
+    let maxLat = Number.NEGATIVE_INFINITY;
+    let validPoints = 0;
+
+    for (const pt of screenPoints) {
+      const cartesian = camera.pickEllipsoid(pt, ellipsoid);
+      if (cartesian) {
+        const carto = Cartographic.fromCartesian(cartesian);
+        if (carto) {
+          minLon = Math.min(minLon, carto.longitude);
+          maxLon = Math.max(maxLon, carto.longitude);
+          minLat = Math.min(minLat, carto.latitude);
+          maxLat = Math.max(maxLat, carto.latitude);
+          validPoints++;
+        }
+      }
+    }
+
+    // If all 9 points successfully hit the globe, we have a geometrically perfect bounding box.
+    if (validPoints === screenPoints.length) {
+      // Safety check to prevent wrap-around bugs if zoomed out near the poles or antimeridian
+      if (maxLon - minLon < Math.PI) {
+        return new Rectangle(minLon, minLat, maxLon, maxLat);
+      }
+    }
+
+    // Fallback: if the camera is pitched such that some rays miss the Earth (e.g. sky is visible),
+    // use Cesium's internal View Frustum calculator. It safely handles horizon calculations.
+    const nativeRect = camera.computeViewRectangle(ellipsoid);
+    if (nativeRect) {
+      return nativeRect;
+    }
+
+    // Absolute fallback to Terria's basic cache
+    return currentView.rectangle;
+  }
+
+  private renderDebugRectangles(cameraRect: Rectangle, queryRect: Rectangle) {
+    if (!this.getRerPoiTrait("showDebugBBox")) {
+      if (this.debugDataSource) {
+        runInAction(() => {
+          this.debugDataSource = undefined;
+        });
+        this.terria.currentViewer.notifyRepaintRequired();
+      }
+      return;
+    }
+
+    runInAction(() => {
+      if (!this.debugDataSource) {
+        this.debugDataSource = new CustomDataSource("RerPoiDebugBBox");
+      }
+    });
+
+    const entities = this.debugDataSource!.entities;
+    entities.suspendEvents();
+    entities.removeAll();
+
+    entities.add({
+      name: "Camera View Rectangle",
+      rectangle: {
+        coordinates: cameraRect,
+        material: Color.BLUE.withAlpha(0.2),
+        outline: true,
+        outlineColor: Color.BLUE,
+        height: 500
+      }
+    } as any);
+
+    entities.add({
+      name: "Padded Query BBox",
+      rectangle: {
+        coordinates: queryRect,
+        material: Color.RED.withAlpha(0.2),
+        outline: true,
+        outlineColor: Color.RED,
+        height: 500
+      }
+    } as any);
+
+    entities.resumeEvents();
+    this.terria.currentViewer.notifyRepaintRequired();
+  }
+
   private getDynamicViewportQuery(): DynamicViewportQuery | undefined {
     if (
       this.terria.currentViewer.type === "none" ||
@@ -734,17 +859,12 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       return undefined;
     }
 
-    const currentView = this.terria.currentViewer.getCurrentCameraView();
-    const pitch =
-      (currentView as { pitch?: number }).pitch ??
-      this.terria.cesium?.scene.camera.pitch;
-
+    // Inject our new precision screen calculating method here
+    const screenRectangle = this.getScreenBoundingBox();
     const paddingRatio = this.getRerPoiTrait("queryBboxPaddingRatio");
-    const queryRectangle = rectangleWithPadding(
-      currentView.rectangle,
-      paddingRatio,
-      getPaddingMultiplierForPitch(pitch, 1.5, 6)
-    );
+    const queryRectangle = rectangleWithPadding(screenRectangle, paddingRatio);
+
+    this.renderDebugRectangles(screenRectangle, queryRectangle);
 
     if (rectangleArea(queryRectangle) <= 0) return undefined;
 
@@ -820,46 +940,28 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
 
 function rectangleWithPadding(
   rectangle: Rectangle,
-  paddingRatio: number,
-  verticalPaddingMultiplier = 1
+  paddingRatio: number
 ): Rectangle {
   const width = Rectangle.computeWidth(rectangle);
   const height = Rectangle.computeHeight(rectangle);
   const safePadding = Math.max(0, paddingRatio);
-  const southMult = CesiumMath.clamp(verticalPaddingMultiplier, 1, 3);
-  const northMult = CesiumMath.clamp(verticalPaddingMultiplier, 1, 6);
   const lonPad = width * safePadding;
   const latPad = height * safePadding;
 
   return new Rectangle(
     CesiumMath.clamp(rectangle.west - lonPad, -Math.PI, Math.PI),
     CesiumMath.clamp(
-      rectangle.south - latPad * southMult,
+      rectangle.south - latPad,
       -CesiumMath.PI_OVER_TWO,
       CesiumMath.PI_OVER_TWO
     ),
     CesiumMath.clamp(rectangle.east + lonPad, -Math.PI, Math.PI),
     CesiumMath.clamp(
-      rectangle.north + latPad * northMult,
+      rectangle.north + latPad,
       -CesiumMath.PI_OVER_TWO,
       CesiumMath.PI_OVER_TWO
     )
   );
-}
-
-function getPaddingMultiplierForPitch(
-  pitch: number | undefined,
-  minMultiplier: number,
-  maxMultiplier: number
-): number {
-  if (!isDefined(pitch)) return minMultiplier;
-  const safeMin = Math.max(1, minMultiplier);
-  const safeMax = Math.max(safeMin, maxMultiplier);
-  const pitchRatio =
-    (CesiumMath.clamp(pitch, -CesiumMath.PI_OVER_TWO, 0) +
-      CesiumMath.PI_OVER_TWO) /
-    CesiumMath.PI_OVER_TWO;
-  return safeMin + pitchRatio * (safeMax - safeMin);
 }
 
 function rectangleArea(rectangle: Rectangle): number {

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -1,0 +1,755 @@
+import { featureCollection } from "@turf/helpers";
+import { Geometry, GeometryCollection, Properties } from "@turf/helpers";
+import {
+  onBecomeObserved,
+  onBecomeUnobserved,
+  reaction,
+  runInAction
+} from "mobx";
+import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import CesiumMath from "terriajs-cesium/Source/Core/Math";
+import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
+import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import URI from "urijs";
+import isDefined from "../../../Core/isDefined";
+import loadJson from "../../../Core/loadJson";
+import { networkRequestError } from "../../../Core/TerriaError";
+import featureDataToGeoJson from "../../../Map/PickedFeatures/featureDataToGeoJson";
+import { FeatureCollectionWithCrs } from "../../../ModelMixins/GeojsonMixin";
+import CommonStrata from "../../Definition/CommonStrata";
+import { BaseModel, ModelConstructorParameters } from "../../Definition/Model";
+import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
+import ArcGisFeatureServerCatalogItem from "./ArcGisFeatureServerCatalogItem";
+import {
+  applyRerPoiEntityStyles,
+  RER_POI_CATALOG_ITEM_TYPE,
+  normalizeRerPoiUrl
+} from "../../../ModelMixins/RerPoiHelpers";
+import RerPoiCatalogItemTraits, {
+  defaultRerPoiCatalogItemTraits
+} from "../../../Traits/TraitsClasses/RerPoiCatalogItemTraits";
+
+interface EsriJsonQueryOptions {
+  resultOffset?: number;
+  bbox?: Rectangle;
+  minLevelId?: number;
+  maxLevelId?: number;
+}
+
+interface DynamicViewportQuery {
+  filterKey: string;
+  queryRectangle: Rectangle;
+  requestOptions: EsriJsonQueryOptions;
+}
+
+interface EsriJsonFeatureServerResponse {
+  features?: any[];
+  exceededTransferLimit?: boolean;
+}
+
+export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
+  static readonly type = RER_POI_CATALOG_ITEM_TYPE;
+  static readonly TraitsClass = RerPoiCatalogItemTraits;
+  static readonly traits = RerPoiCatalogItemTraits.traits;
+
+  readonly TraitsClass = RerPoiCatalogItemTraits;
+  readonly traits = RerPoiCatalogItemTraits.traits;
+
+  private removeCesiumCameraChangedListener: (() => void) | undefined;
+  private removeViewerChangedListener: (() => void) | undefined;
+  private removeShowReaction: (() => void) | undefined;
+
+  private dynamicReloadTimer: ReturnType<typeof setTimeout> | undefined;
+  private pendingDynamicQuery: DynamicViewportQuery | undefined;
+  private activeDynamicQuery: DynamicViewportQuery | undefined;
+  private dynamicReloadQueued = false;
+  private dynamicReloadInProgress = false;
+
+  private managedDataSource: GeoJsonDataSource | undefined;
+  private liveEntityByObjectId = new Map<string, any>();
+  private isFirstDynamicLoad = true;
+
+  private readonly onDynamicViewportChanged = () => {
+    if (this.isCameraPastTiltLimit()) return;
+    this.queueDynamicReload();
+  };
+
+  constructor(...args: ModelConstructorParameters) {
+    super(...args);
+    this.setTrait(CommonStrata.definition, "forceCesiumPrimitives", true);
+    this.setTrait(CommonStrata.definition, "clustering", {
+      enabled: true,
+      pixelRange: 35,
+      minimumClusterSize: 5,
+      pinSize: 60,
+      pinBackgroundColor: "gray"
+    });
+
+    onBecomeObserved(this, "mapItems", () =>
+      this.startDynamicViewportRequests()
+    );
+    onBecomeUnobserved(this, "mapItems", () =>
+      this.stopDynamicViewportRequests()
+    );
+  }
+
+  get type(): string {
+    return RER_POI_CATALOG_ITEM_TYPE;
+  }
+
+  get objectIdField(): string {
+    const stratum = this.strata.get("featureServer") as any;
+    return stratum?._featureServer?.objectIdField ?? "OBJECTID";
+  }
+
+  private getRerPoiTrait<T extends keyof RerPoiCatalogItemTraits>(
+    traitName: T
+  ): RerPoiCatalogItemTraits[T] {
+    const trait = RerPoiCatalogItemTraits.traits[traitName as string];
+    const value = trait?.getValue(this as unknown as BaseModel);
+    return value === undefined
+      ? defaultRerPoiCatalogItemTraits[traitName]
+      : (value as RerPoiCatalogItemTraits[T]);
+  }
+
+  private startDynamicViewportRequests() {
+    if (!this.removeViewerChangedListener) {
+      this.removeViewerChangedListener =
+        this.terria.mainViewer.afterViewerChanged.addEventListener(() => {
+          this.attachCurrentViewerListener();
+          this.queueDynamicReload(true);
+        });
+    }
+
+    this.removeShowReaction ??= reaction(
+      () => this.show,
+      (show) => {
+        if (show) this.queueDynamicReload(true);
+      }
+    );
+
+    this.attachCurrentViewerListener();
+    this.queueDynamicReload(true);
+  }
+
+  private stopDynamicViewportRequests() {
+    this.detachCurrentViewerListener();
+    this.removeShowReaction?.();
+    this.removeShowReaction = undefined;
+    this.removeViewerChangedListener?.();
+    this.removeViewerChangedListener = undefined;
+
+    if (this.dynamicReloadTimer) {
+      clearTimeout(this.dynamicReloadTimer);
+      this.dynamicReloadTimer = undefined;
+    }
+
+    this.dynamicReloadQueued = false;
+    this.dynamicReloadInProgress = false;
+    this.managedDataSource = undefined;
+    this.liveEntityByObjectId.clear();
+    this.isFirstDynamicLoad = true;
+  }
+
+  private attachCurrentViewerListener() {
+    this.detachCurrentViewerListener();
+    const cesium = this.terria.cesium;
+    if (cesium) {
+      this.removeCesiumCameraChangedListener =
+        cesium.scene.camera.changed.addEventListener(
+          this.onDynamicViewportChanged
+        );
+    }
+  }
+
+  private detachCurrentViewerListener() {
+    this.removeCesiumCameraChangedListener?.();
+    this.removeCesiumCameraChangedListener = undefined;
+  }
+
+  private isCameraPastTiltLimit(): boolean {
+    const cameraTiltLimitRadians = CesiumMath.clamp(
+      CesiumMath.toRadians(this.getRerPoiTrait("cameraTiltLimitDegrees")),
+      0,
+      CesiumMath.PI_OVER_TWO
+    );
+    const currentView = this.terria.currentViewer.getCurrentCameraView();
+    const pitch =
+      (currentView as { pitch?: number }).pitch ??
+      this.terria.cesium?.scene.camera.pitch;
+    if (!isDefined(pitch)) return false;
+    const tiltThresholdPitch = -CesiumMath.PI_OVER_TWO + cameraTiltLimitRadians;
+    return pitch > tiltThresholdPitch;
+  }
+
+  private queueDynamicReload(immediate = false) {
+    if (this.dynamicReloadTimer) {
+      clearTimeout(this.dynamicReloadTimer);
+      this.dynamicReloadTimer = undefined;
+    }
+    const debounceMs = this.getRerPoiTrait("dynamicRequestDebounceMs");
+    this.dynamicReloadTimer = setTimeout(
+      () => {
+        this.dynamicReloadTimer = undefined;
+        void this.reloadDynamicViewportData();
+      },
+      immediate ? 0 : debounceMs
+    );
+  }
+
+  private async reloadDynamicViewportData() {
+    if (!this.show || this.isCameraPastTiltLimit()) return;
+
+    const nextQuery = this.getDynamicViewportQuery();
+    if (!nextQuery) return;
+
+    if (
+      this.activeDynamicQuery?.filterKey === nextQuery.filterKey &&
+      rectangleContains(
+        this.activeDynamicQuery.queryRectangle,
+        nextQuery.queryRectangle
+      )
+    ) {
+      return;
+    }
+
+    if (this.dynamicReloadInProgress || this.isLoadingMapItems) {
+      this.dynamicReloadQueued = true;
+      return;
+    }
+
+    this.dynamicReloadInProgress = true;
+    try {
+      if (this.isFirstDynamicLoad || !this.managedDataSource) {
+        this.pendingDynamicQuery = nextQuery;
+        (await this.loadMapItems(true)).logError(
+          "Failed to reload RerPoi dynamic viewport data"
+        );
+        this.pendingDynamicQuery = undefined;
+
+        const ds = this.findGeoJsonDataSource();
+        if (ds) {
+          this.managedDataSource = ds;
+          this.buildLiveEntityMap(ds);
+          this.activeDynamicQuery = nextQuery;
+          this.isFirstDynamicLoad = false;
+          this.syncCachedEntityVisibility(nextQuery);
+        }
+      } else {
+        await this.applyIncrementalUpdate(nextQuery);
+      }
+    } finally {
+      this.dynamicReloadInProgress = false;
+      if (this.dynamicReloadQueued) {
+        const shouldRetry = !this.isCameraPastTiltLimit();
+        this.dynamicReloadQueued = false;
+        if (shouldRetry) this.queueDynamicReload(true);
+      }
+    }
+  }
+
+  private findGeoJsonDataSource(): GeoJsonDataSource | undefined {
+    for (const item of this.mapItems) {
+      if (item instanceof GeoJsonDataSource) return item;
+    }
+    return undefined;
+  }
+
+  private buildLiveEntityMap(ds: GeoJsonDataSource) {
+    const now = JulianDate.now();
+    this.liveEntityByObjectId.clear();
+    for (const entity of ds.entities.values) {
+      const id = this.readObjectIdFromEntity(entity, now);
+      if (id) this.liveEntityByObjectId.set(id, entity);
+    }
+  }
+
+  private syncCachedEntityVisibility(query = this.getDynamicViewportQuery()) {
+    if (!query || !this.managedDataSource) return;
+    const now = JulianDate.now();
+    const { minLevelId, maxLevelId } = query.requestOptions;
+    for (const entity of this.liveEntityByObjectId.values()) {
+      const inRectangle = isEntityInRectangle(entity, query.queryRectangle);
+      const inLevelRange = this.isEntityInLevelRange(
+        entity,
+        now,
+        minLevelId,
+        maxLevelId
+      );
+      entity.show = inRectangle && inLevelRange;
+    }
+  }
+
+  private isEntityInLevelRange(
+    entity: any,
+    now: JulianDate,
+    minLevelId: number | undefined,
+    maxLevelId: number | undefined
+  ): boolean {
+    const levelIdField = this.getRerPoiTrait("levelIdField");
+    if (!levelIdField) return true;
+    if (!isDefined(minLevelId) && !isDefined(maxLevelId)) return true;
+
+    const raw = entity.properties?.[levelIdField]?.getValue(now);
+    if (!isDefined(raw)) return false;
+
+    const levelId = Number(raw);
+    if (!Number.isFinite(levelId)) return false;
+    if (isDefined(minLevelId) && levelId < minLevelId) return false;
+    if (isDefined(maxLevelId) && levelId > maxLevelId) return false;
+    return true;
+  }
+
+  private readObjectIdFromEntity(
+    entity: any,
+    now: JulianDate
+  ): string | undefined {
+    const props = entity.properties;
+    if (!props) return undefined;
+    const raw =
+      props[this.objectIdField]?.getValue(now) ??
+      props["OBJECTID"]?.getValue(now) ??
+      props["objectid"]?.getValue(now);
+    return raw !== undefined && raw !== null ? String(raw) : undefined;
+  }
+
+  private getFeatureObjectId(feature: any): string | undefined {
+    const props = feature.properties as Record<string, unknown> | null;
+    if (!props) return undefined;
+    const raw =
+      props[this.objectIdField] ?? props["OBJECTID"] ?? props["objectid"];
+    return raw !== undefined && raw !== null ? String(raw) : undefined;
+  }
+
+  private async applyIncrementalUpdate(nextQuery: DynamicViewportQuery) {
+    const ds = this.managedDataSource!;
+
+    let geoJson: FeatureCollectionWithCrs<
+      Geometry | GeometryCollection,
+      Properties
+    >;
+    try {
+      geoJson = await this.loadGeoJsonFromServer(nextQuery.requestOptions);
+    } catch {
+      return;
+    }
+
+    const newFeatures = (geoJson.features ?? []) as any[];
+    if (newFeatures.length === 0) return;
+
+    const pruneRect = rectangleWithPadding(nextQuery.queryRectangle, 0.5);
+    const idsToRemove: string[] = [];
+    for (const [id, entity] of this.liveEntityByObjectId) {
+      if (!isEntityInRectangle(entity, pruneRect)) idsToRemove.push(id);
+    }
+
+    const featuresToAdd = newFeatures.filter((f) => {
+      const id = this.getFeatureObjectId(f);
+      return id ? !this.liveEntityByObjectId.has(id) : false;
+    });
+
+    if (idsToRemove.length > 0) {
+      ds.entities.suspendEvents();
+      for (const id of idsToRemove) {
+        const entity = this.liveEntityByObjectId.get(id);
+        if (entity) ds.entities.remove(entity);
+        this.liveEntityByObjectId.delete(id);
+      }
+      ds.entities.resumeEvents();
+    }
+
+    if (featuresToAdd.length > 0) {
+      const idsBefore = new Set<string>(
+        ds.entities.values.map((e: any) => e.id as string)
+      );
+      await ds.process(featureCollection(featuresToAdd));
+
+      const now = JulianDate.now();
+      const newEntities = ds.entities.values.filter(
+        (e: any) => !idsBefore.has(e.id as string)
+      );
+      applyRerPoiEntityStyles(ds, {
+        defaultMarkerColor: this.getRerPoiTrait("defaultMarkerColor"),
+        markerSize: this.getRerPoiTrait("markerSize"),
+        iconStrokeWidth: this.getRerPoiTrait("iconStrokeWidth"),
+        iconStrokeColor: this.getRerPoiTrait("iconStrokeColor"),
+        poiDomainStyleGroups: this.getRerPoiTrait("poiDomainStyleGroups"),
+        scaleField: this.getRerPoiTrait("scaleField"),
+        domainIdField: this.getRerPoiTrait("domainIdField")
+      });
+      for (const entity of newEntities) {
+        const id = this.readObjectIdFromEntity(entity, now);
+        if (id) this.liveEntityByObjectId.set(id, entity);
+      }
+    }
+
+    this.activeDynamicQuery = nextQuery;
+    this.syncCachedEntityVisibility(nextQuery);
+  }
+
+  protected async forceLoadGeojsonData(): Promise<
+    FeatureCollectionWithCrs<Geometry | GeometryCollection, Properties>
+  > {
+    if (this.isCameraPastTiltLimit()) {
+      return featureCollection([]) as any;
+    }
+
+    const dynamicQuery =
+      this.pendingDynamicQuery ?? this.getDynamicViewportQuery();
+
+    if (!dynamicQuery) {
+      return featureCollection([]) as any;
+    }
+
+    try {
+      const geoJson = await this.loadGeoJsonFromServer(
+        dynamicQuery.requestOptions
+      );
+      const featureCount = geoJson.features?.length ?? 0;
+
+      if (featureCount > 0 && featureCount <= this.maxFeatures) {
+        return geoJson;
+      }
+      return featureCollection([]) as any;
+    } catch {
+      return featureCollection([]) as any;
+    }
+  }
+
+  protected async loadGeoJsonDataSource(
+    geoJson: FeatureCollectionWithCrs<Geometry | GeometryCollection, Properties>
+  ): Promise<GeoJsonDataSource> {
+    const dataSource = await super.loadGeoJsonDataSource(geoJson as any);
+    applyRerPoiEntityStyles(dataSource, {
+      defaultMarkerColor: this.getRerPoiTrait("defaultMarkerColor"),
+      markerSize: this.getRerPoiTrait("markerSize"),
+      iconStrokeWidth: this.getRerPoiTrait("iconStrokeWidth"),
+      iconStrokeColor: this.getRerPoiTrait("iconStrokeColor"),
+      poiDomainStyleGroups: this.getRerPoiTrait("poiDomainStyleGroups"),
+      scaleField: this.getRerPoiTrait("scaleField"),
+      domainIdField: this.getRerPoiTrait("domainIdField")
+    });
+    return dataSource;
+  }
+
+  protected async loadGeoJsonFromServer(
+    queryOptions?: EsriJsonQueryOptions
+  ): Promise<
+    FeatureCollectionWithCrs<Geometry | GeometryCollection, Properties>
+  > {
+    const supportsPagination = this.supportsPagination;
+    const featuresPerRequest = this.featuresPerRequest;
+    const maxFeatures = this.maxFeatures;
+    const objectIdField = this.objectIdField;
+
+    const fetchPage = async (
+      resultOffset?: number
+    ): Promise<EsriJsonFeatureServerResponse> => {
+      const urlString = runInAction(() =>
+        this.buildEsriJsonUrl({ ...queryOptions, resultOffset })
+      );
+      return loadJson(urlString);
+    };
+
+    const getObjectId = (feature: any): string | undefined =>
+      feature.attributes?.[objectIdField] ??
+      feature.attributes?.OBJECTID ??
+      feature.attributes?.objectid;
+
+    const extractIds = (features: any[]): string[] =>
+      features.map(getObjectId).filter((id): id is string => isDefined(id));
+
+    if (!supportsPagination) {
+      const page = await fetchPage();
+      const count = page.features?.length ?? 0;
+
+      if (count === 0) throw new Error("RerPoi query returned no features");
+      if (count > maxFeatures)
+        throw new Error("RerPoi query exceeded the maximum feature limit");
+      if (page.exceededTransferLimit === true)
+        throw new Error("RerPoi query exceeded transfer limit");
+
+      return (featureDataToGeoJson(page) ?? {
+        type: "FeatureCollection",
+        features: []
+      }) as any;
+    }
+
+    const combined = await fetchPage(0);
+    combined.features ??= [];
+
+    if (combined.features.length === 0)
+      throw new Error("RerPoi query returned no features");
+    if (combined.features.length > maxFeatures)
+      throw new Error("RerPoi query exceeded the maximum feature limit");
+
+    const seenIDs = new Set<string>(extractIds(combined.features));
+    let currentOffset = 0;
+    let exceededTransferLimit = combined.exceededTransferLimit === true;
+
+    while (exceededTransferLimit) {
+      currentOffset += featuresPerRequest;
+      const page = await fetchPage(currentOffset);
+      const pageFeatures = page.features ?? [];
+      if (!pageFeatures.length) break;
+
+      const newIds = extractIds(pageFeatures);
+      if (newIds.length > 0 && newIds.every((id) => seenIDs.has(id))) break;
+
+      if (combined.features.length + pageFeatures.length > maxFeatures)
+        throw new Error("RerPoi query exceeded the maximum feature limit");
+
+      newIds.forEach((id) => seenIDs.add(id));
+      combined.features = combined.features.concat(pageFeatures);
+      exceededTransferLimit = page.exceededTransferLimit === true;
+    }
+
+    if (combined.features.length === 0)
+      throw new Error("RerPoi query returned no features");
+    if (combined.features.length > maxFeatures)
+      throw new Error("RerPoi query exceeded the maximum feature limit");
+
+    return (featureDataToGeoJson(combined) ?? {
+      type: "FeatureCollection",
+      features: []
+    }) as any;
+  }
+
+  buildEsriJsonUrl(options?: number | EsriJsonQueryOptions): string {
+    const queryOptions =
+      typeof options === "number" ? { resultOffset: options } : options;
+
+    const url = normalizeRerPoiUrl(this.url || "0d");
+
+    if (!/^(.*(?:FeatureServer|MapServer))\/(\d+)/.test(url)) {
+      throw networkRequestError({
+        title: "Invalid RerPoi URL",
+        message: `URL must point to a layer on an ArcGIS FeatureServer or MapServer. Received: ${url}`
+      });
+    }
+
+    const combinedWhere = [
+      this.where,
+      this.buildLevelFilterClause(
+        queryOptions?.minLevelId,
+        queryOptions?.maxLevelId
+      )
+    ]
+      .filter(
+        (clause): clause is string => isDefined(clause) && clause.length > 0
+      )
+      .map((clause) => `(${clause})`)
+      .join(" AND ");
+
+    const uri = new URI(url)
+      .segment("query")
+      .addQuery("f", "json")
+      .addQuery("where", combinedWhere || "1=1")
+      .addQuery("outFields", "*")
+      .addQuery("outSR", "4326");
+
+    if (queryOptions?.bbox) {
+      uri
+        .addQuery("geometry", rectangleToBounds(queryOptions.bbox))
+        .addQuery("geometryType", "esriGeometryEnvelope")
+        .addQuery("inSR", "4326")
+        .addQuery("spatialRel", "esriSpatialRelIntersects")
+        .addQuery("returnGeometry", "true");
+    }
+
+    if (queryOptions?.resultOffset !== undefined) {
+      uri
+        .addQuery("resultRecordCount", this.featuresPerRequest)
+        .addQuery("resultOffset", queryOptions.resultOffset);
+    }
+
+    return proxyCatalogItemUrl(this, uri.toString());
+  }
+
+  private buildLevelFilterClause(
+    minLevelId: number | undefined,
+    maxLevelId: number | undefined
+  ): string | undefined {
+    const field = this.getRerPoiTrait("levelIdField");
+    if (!field) return undefined;
+    if (isDefined(minLevelId) && isDefined(maxLevelId)) {
+      return minLevelId === maxLevelId
+        ? `${field} = ${minLevelId}`
+        : `${field} >= ${minLevelId} AND ${field} <= ${maxLevelId}`;
+    }
+    if (isDefined(minLevelId)) return `${field} >= ${minLevelId}`;
+    if (isDefined(maxLevelId)) return `${field} <= ${maxLevelId}`;
+    return undefined;
+  }
+
+  private getDynamicViewportQuery(): DynamicViewportQuery | undefined {
+    if (
+      this.terria.currentViewer.type === "none" ||
+      this.isCameraPastTiltLimit()
+    ) {
+      return undefined;
+    }
+
+    const currentView = this.terria.currentViewer.getCurrentCameraView();
+    const pitch =
+      (currentView as { pitch?: number }).pitch ??
+      this.terria.cesium?.scene.camera.pitch;
+
+    const paddingRatio = this.getRerPoiTrait("queryBboxPaddingRatio");
+    const queryRectangle = rectangleWithPadding(
+      currentView.rectangle,
+      paddingRatio,
+      getPaddingMultiplierForPitch(pitch, 1.5, 6)
+    );
+
+    if (rectangleArea(queryRectangle) <= 0) return undefined;
+
+    const levelFilter = this.getLevelFilterForViewport();
+    return {
+      filterKey: levelFilter.filterKey,
+      queryRectangle,
+      requestOptions: {
+        bbox: queryRectangle,
+        minLevelId: levelFilter.minLevelId,
+        maxLevelId: levelFilter.maxLevelId
+      }
+    };
+  }
+
+  private getLevelFilterForViewport(): {
+    minLevelId: number;
+    maxLevelId: number;
+    filterKey: string;
+  } {
+    const minLevelId = this.getRerPoiTrait("minLevelId");
+    let maxLevelId = this.getRerPoiTrait("maxLevelId");
+    const cameraHeight = this.getCurrentCameraHeight();
+    const farHeight = this.getRerPoiTrait("progressiveFarCameraHeight");
+
+    if (cameraHeight !== undefined) {
+      if (cameraHeight >= farHeight) {
+        maxLevelId = minLevelId;
+      } else if (maxLevelId > minLevelId) {
+        maxLevelId = this.getProgressiveLevelIdFromHeight(
+          cameraHeight,
+          minLevelId,
+          maxLevelId
+        );
+      }
+    }
+
+    const levelIdField = this.getRerPoiTrait("levelIdField");
+    return {
+      minLevelId,
+      maxLevelId,
+      filterKey: [this.where, levelIdField, minLevelId, maxLevelId].join("|")
+    };
+  }
+
+  private getProgressiveLevelIdFromHeight(
+    cameraHeight: number,
+    minimumLevelId: number,
+    maximumLevelId: number
+  ): number {
+    const nearHeight = this.getRerPoiTrait("progressiveNearCameraHeight");
+    const farHeight = this.getRerPoiTrait("progressiveFarCameraHeight");
+    const levelStep = this.getRerPoiTrait("progressiveLevelStep");
+
+    const clampedHeight = CesiumMath.clamp(cameraHeight, nearHeight, farHeight);
+    const zoomRatio =
+      1 - (clampedHeight - nearHeight) / (farHeight - nearHeight);
+    const continuousLevel =
+      minimumLevelId + zoomRatio * (maximumLevelId - minimumLevelId);
+    const steppedLevel =
+      minimumLevelId +
+      Math.floor((continuousLevel - minimumLevelId) / levelStep) * levelStep;
+
+    return CesiumMath.clamp(steppedLevel, minimumLevelId, maximumLevelId);
+  }
+
+  private getCurrentCameraHeight(): number | undefined {
+    const position = this.terria.currentViewer.getCurrentCameraView().position;
+    if (!position) return undefined;
+    return Cartographic.fromCartesian(position)?.height;
+  }
+}
+
+function rectangleWithPadding(
+  rectangle: Rectangle,
+  paddingRatio: number,
+  verticalPaddingMultiplier = 1
+): Rectangle {
+  const width = Rectangle.computeWidth(rectangle);
+  const height = Rectangle.computeHeight(rectangle);
+  const safePadding = Math.max(0, paddingRatio);
+  const southMult = CesiumMath.clamp(verticalPaddingMultiplier, 1, 3);
+  const northMult = CesiumMath.clamp(verticalPaddingMultiplier, 1, 6);
+  const lonPad = width * safePadding;
+  const latPad = height * safePadding;
+
+  return new Rectangle(
+    CesiumMath.clamp(rectangle.west - lonPad, -Math.PI, Math.PI),
+    CesiumMath.clamp(
+      rectangle.south - latPad * southMult,
+      -CesiumMath.PI_OVER_TWO,
+      CesiumMath.PI_OVER_TWO
+    ),
+    CesiumMath.clamp(rectangle.east + lonPad, -Math.PI, Math.PI),
+    CesiumMath.clamp(
+      rectangle.north + latPad * northMult,
+      -CesiumMath.PI_OVER_TWO,
+      CesiumMath.PI_OVER_TWO
+    )
+  );
+}
+
+function getPaddingMultiplierForPitch(
+  pitch: number | undefined,
+  minMultiplier: number,
+  maxMultiplier: number
+): number {
+  if (!isDefined(pitch)) return minMultiplier;
+  const safeMin = Math.max(1, minMultiplier);
+  const safeMax = Math.max(safeMin, maxMultiplier);
+  const pitchRatio =
+    (CesiumMath.clamp(pitch, -CesiumMath.PI_OVER_TWO, 0) +
+      CesiumMath.PI_OVER_TWO) /
+    CesiumMath.PI_OVER_TWO;
+  return safeMin + pitchRatio * (safeMax - safeMin);
+}
+
+function rectangleArea(rectangle: Rectangle): number {
+  return Rectangle.computeWidth(rectangle) * Rectangle.computeHeight(rectangle);
+}
+
+function rectangleContains(container: Rectangle, value: Rectangle): boolean {
+  return (
+    container.west <= value.west &&
+    container.south <= value.south &&
+    container.east >= value.east &&
+    container.north >= value.north
+  );
+}
+
+function rectangleToBounds(rectangle: Rectangle): string {
+  return [
+    CesiumMath.toDegrees(rectangle.west),
+    CesiumMath.toDegrees(rectangle.south),
+    CesiumMath.toDegrees(rectangle.east),
+    CesiumMath.toDegrees(rectangle.north)
+  ].join(",");
+}
+
+function isEntityInRectangle(entity: any, rect: Rectangle): boolean {
+  const pos = entity.position?.getValue(JulianDate.now());
+  if (!pos) return true;
+  const carto = Cartographic.fromCartesian(pos);
+  if (!carto) return true;
+  return (
+    carto.longitude >= rect.west &&
+    carto.longitude <= rect.east &&
+    carto.latitude >= rect.south &&
+    carto.latitude <= rect.north
+  );
+}

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -369,7 +369,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       const newEntities = ds.entities.values.filter(
         (e: any) => !idsBefore.has(e.id as string)
       );
-      applyRerPoiEntityStyles(ds, {
+
+      // Apply styles ONLY to the new entities
+      applyRerPoiEntityStyles(ds, newEntities, {
         defaultMarkerColor: this.getRerPoiTrait("defaultMarkerColor"),
         markerSize: this.getRerPoiTrait("markerSize"),
         iconStrokeWidth: this.getRerPoiTrait("iconStrokeWidth"),
@@ -427,7 +429,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     geoJson: FeatureCollectionWithCrs<Geometry | GeometryCollection, Properties>
   ): Promise<GeoJsonDataSource> {
     const dataSource = await super.loadGeoJsonDataSource(geoJson as any);
-    applyRerPoiEntityStyles(dataSource, {
+    
+    // Apply styles to all entities on the initial load
+    applyRerPoiEntityStyles(dataSource, dataSource.entities.values, {
       defaultMarkerColor: this.getRerPoiTrait("defaultMarkerColor"),
       markerSize: this.getRerPoiTrait("markerSize"),
       iconStrokeWidth: this.getRerPoiTrait("iconStrokeWidth"),

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -338,7 +338,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         maxLevelId
       );
       const matchesQueryableFilters = this.matchesQueryableFilters(entity, now);
-      const isVisible = inRectangle && inLevelRange && matchesQueryableFilters;
+      const isVisible =
+        this.isProtectedLevelId(entity, now) ||
+        (inRectangle && inLevelRange && matchesQueryableFilters);
       entity.show = isVisible;
       if (isVisible) visiblePoiCount += 1;
     }
@@ -375,6 +377,16 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     if (isDefined(minLevelId) && levelId < minLevelId) return false;
     if (isDefined(maxLevelId) && levelId > maxLevelId) return false;
     return true;
+  }
+
+  private isProtectedLevelId(entity: any, now: JulianDate): boolean {
+    const levelIdField = this.getRerPoiTrait("levelIdField");
+    if (!levelIdField) return false;
+
+    const raw = entity.properties?.[levelIdField]?.getValue(now);
+    if (!isDefined(raw)) return false;
+
+    return Number(raw) === 7;
   }
 
   private readObjectIdFromEntity(
@@ -468,9 +480,15 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     if (newFeatures.length === 0) return;
 
     const pruneRect = rectangleWithPadding(nextQuery.queryRectangle, 0.5);
+    const now = JulianDate.now();
     const idsToRemove: string[] = [];
     for (const [id, entity] of this.liveEntityByObjectId) {
-      if (!isEntityInRectangle(entity, pruneRect)) idsToRemove.push(id);
+      if (
+        !isEntityInRectangle(entity, pruneRect) &&
+        !this.isProtectedLevelId(entity, now)
+      ) {
+        idsToRemove.push(id);
+      }
     }
 
     const featuresToAdd = newFeatures.filter((f) => {

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -10,8 +10,10 @@ import {
   makeObservable
 } from "mobx";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
+import EllipsoidGeodesic from "terriajs-cesium/Source/Core/EllipsoidGeodesic";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import URI from "urijs";
@@ -31,8 +33,11 @@ import {
   normalizeRerPoiUrl
 } from "../../../ModelMixins/RerPoiHelpers";
 import RerPoiCatalogItemTraits, {
-  defaultRerPoiCatalogItemTraits
+  defaultRerPoiCatalogItemTraits,
+  LevelIdCameraHeightMapping
 } from "../../../Traits/TraitsClasses/RerPoiCatalogItemTraits";
+
+const geodesic = new EllipsoidGeodesic();
 
 interface EsriJsonQueryOptions {
   resultOffset?: number;
@@ -202,6 +207,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     this.liveEntityByObjectId.clear();
     this.isFirstDynamicLoad = true;
   }
+
   private attachCurrentViewerListener() {
     this.detachCurrentViewerListener();
     const cesium = this.terria.cesium;
@@ -347,7 +353,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       cachedPoiCount: this.liveEntityByObjectId.size,
       visiblePoiCount,
       totalPoiCount,
-      cameraHeight: this.getCurrentCameraHeight(),
+      viewerScale: this.getCurrentViewerScale(),
       minLevelId,
       maxLevelId
     });
@@ -766,21 +772,12 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     filterKey: string;
   } {
     const minLevelId = this.getRerPoiTrait("minLevelId");
-    let maxLevelId = this.getRerPoiTrait("maxLevelId");
-    const cameraHeight = this.getCurrentCameraHeight();
-    const farHeight = this.getRerPoiTrait("progressiveFarCameraHeight");
+    const viewerScale = this.getCurrentViewerScale();
 
-    if (cameraHeight !== undefined) {
-      if (cameraHeight >= farHeight) {
-        maxLevelId = minLevelId;
-      } else if (maxLevelId > minLevelId) {
-        maxLevelId = this.getProgressiveLevelIdFromHeight(
-          cameraHeight,
-          minLevelId,
-          maxLevelId
-        );
-      }
-    }
+    const maxLevelId =
+      viewerScale === undefined
+        ? minLevelId - 1
+        : this.getProgressiveLevelIdFromScale(viewerScale, minLevelId);
 
     const levelIdField = this.getRerPoiTrait("levelIdField");
     return {
@@ -790,31 +787,78 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     };
   }
 
-  private getProgressiveLevelIdFromHeight(
-    cameraHeight: number,
-    minimumLevelId: number,
-    maximumLevelId: number
-  ): number {
-    const nearHeight = this.getRerPoiTrait("progressiveNearCameraHeight");
-    const farHeight = this.getRerPoiTrait("progressiveFarCameraHeight");
-    const levelStep = this.getRerPoiTrait("progressiveLevelStep");
-
-    const clampedHeight = CesiumMath.clamp(cameraHeight, nearHeight, farHeight);
-    const zoomRatio =
-      1 - (clampedHeight - nearHeight) / (farHeight - nearHeight);
-    const continuousLevel =
-      minimumLevelId + zoomRatio * (maximumLevelId - minimumLevelId);
-    const steppedLevel =
-      minimumLevelId +
-      Math.floor((continuousLevel - minimumLevelId) / levelStep) * levelStep;
-
-    return CesiumMath.clamp(steppedLevel, minimumLevelId, maximumLevelId);
+  private getProgressiveLevelIdMappings(): LevelIdCameraHeightMapping[] {
+    const mappings = this.getRerPoiTrait("levelIdMappings");
+    return mappings.length > 0
+      ? mappings
+      : defaultRerPoiCatalogItemTraits.levelIdMappings;
   }
 
-  private getCurrentCameraHeight(): number | undefined {
-    const position = this.terria.currentViewer.getCurrentCameraView().position;
-    if (!position) return undefined;
-    return Cartographic.fromCartesian(position)?.height;
+  private getProgressiveLevelIdFromScale(
+    viewerScale: number,
+    minimumLevelId: number
+  ): number {
+    const levelIdMappings = this.getProgressiveLevelIdMappings();
+
+    if (levelIdMappings.length === 0) {
+      return minimumLevelId - 1;
+    }
+
+    let lastLevelId = levelIdMappings[levelIdMappings.length - 1].levelId;
+
+    for (const mapping of levelIdMappings) {
+      lastLevelId = mapping.levelId;
+
+      if (viewerScale >= mapping.cameraHeightThreshold) {
+        return mapping.levelId;
+      }
+    }
+
+    return lastLevelId;
+  }
+
+  private getCurrentViewerScale(): number | undefined {
+    const scale = this.terria.mainViewer.scale;
+    if (isDefined(scale) && Number.isFinite(scale)) {
+      // Existing scale is in "hundreds of meters" units:
+      // 639 -> 63.9 km -> 63,900 m
+      return scale * 100;
+    }
+
+    const cesium = this.terria.cesium;
+    if (!cesium) return undefined;
+
+    const scene = cesium.scene;
+    const width = scene.canvas.clientWidth;
+    const height = scene.canvas.clientHeight;
+
+    if (width <= 1 || height <= 1) return undefined;
+
+    const left = scene.camera.getPickRay(
+      new Cartesian2((width / 2) | 0, height - 1)
+    );
+    const right = scene.camera.getPickRay(
+      new Cartesian2((1 + width / 2) | 0, height - 1)
+    );
+
+    if (!isDefined(left) || !isDefined(right)) return undefined;
+
+    const leftPosition = scene.globe.pick(left, scene);
+    const rightPosition = scene.globe.pick(right, scene);
+
+    if (!isDefined(leftPosition) || !isDefined(rightPosition)) return undefined;
+
+    const leftCartographic =
+      scene.globe.ellipsoid.cartesianToCartographic(leftPosition);
+    const rightCartographic =
+      scene.globe.ellipsoid.cartesianToCartographic(rightPosition);
+
+    if (!isDefined(leftCartographic) || !isDefined(rightCartographic)) {
+      return undefined;
+    }
+
+    geodesic.setEndPoints(leftCartographic, rightCartographic);
+    return geodesic.surfaceDistance;
   }
 }
 

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -262,8 +262,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       poiDomainStyleGroups: this.getRerPoiTraitForSnapshot(
         "poiDomainStyleGroups"
       ),
-      queryableProperties:
-        this.getRerPoiTraitForSnapshot("queryableProperties"),
+      queryableProperties: this.getRerPoiTraitForSnapshot(
+        "queryableProperties"
+      ),
       queryBboxPaddingRatio: this.getRerPoiTraitForSnapshot(
         "queryBboxPaddingRatio"
       ),
@@ -1039,11 +1040,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   > {
     const combined = await this.loadEsriJsonFromServer(queryOptions);
 
-
     if (!combined.features || combined.features.length === 0)
       throw new Error("RerPoi query returned no features");
     if (combined.features.length > this.maxFeatures)
-
       throw new Error("RerPoi query exceeded the maximum feature limit");
     if (combined.exceededTransferLimit === true)
       throw new Error("RerPoi query exceeded transfer limit");
@@ -1416,9 +1415,7 @@ function createDefaultRerPoiTraitSnapshot(): RerPoiTraitSnapshot {
     cameraTiltLimitDegrees: getDefaultRerPoiTrait("cameraTiltLimitDegrees"),
     defaultMarkerColor: getDefaultRerPoiTrait("defaultMarkerColor"),
     domainIdField: getDefaultRerPoiTrait("domainIdField"),
-    dynamicRequestDebounceMs: getDefaultRerPoiTrait(
-      "dynamicRequestDebounceMs"
-    ),
+    dynamicRequestDebounceMs: getDefaultRerPoiTrait("dynamicRequestDebounceMs"),
     iconStrokeColor: getDefaultRerPoiTrait("iconStrokeColor"),
     iconStrokeWidth: getDefaultRerPoiTrait("iconStrokeWidth"),
     labelFontSize: getDefaultRerPoiTrait("labelFontSize"),

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -374,8 +374,14 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         markerSize: this.getRerPoiTrait("markerSize"),
         iconStrokeWidth: this.getRerPoiTrait("iconStrokeWidth"),
         iconStrokeColor: this.getRerPoiTrait("iconStrokeColor"),
+        showLabels: this.getRerPoiTrait("showLabels"),
+        labelTextColor: this.getRerPoiTrait("labelTextColor"),
+        labelFontSize: this.getRerPoiTrait("labelFontSize"),
+        labelOutlineWidth: this.getRerPoiTrait("labelOutlineWidth"),
+        labelOutlineColor: this.getRerPoiTrait("labelOutlineColor"),
         poiDomainStyleGroups: this.getRerPoiTrait("poiDomainStyleGroups"),
         scaleField: this.getRerPoiTrait("scaleField"),
+        nameField: this.getRerPoiTrait("nameField"),
         domainIdField: this.getRerPoiTrait("domainIdField")
       });
       for (const entity of newEntities) {
@@ -426,8 +432,14 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       markerSize: this.getRerPoiTrait("markerSize"),
       iconStrokeWidth: this.getRerPoiTrait("iconStrokeWidth"),
       iconStrokeColor: this.getRerPoiTrait("iconStrokeColor"),
+      showLabels: this.getRerPoiTrait("showLabels"),
+      labelTextColor: this.getRerPoiTrait("labelTextColor"),
+      labelFontSize: this.getRerPoiTrait("labelFontSize"),
+      labelOutlineWidth: this.getRerPoiTrait("labelOutlineWidth"),
+      labelOutlineColor: this.getRerPoiTrait("labelOutlineColor"),
       poiDomainStyleGroups: this.getRerPoiTrait("poiDomainStyleGroups"),
       scaleField: this.getRerPoiTrait("scaleField"),
+      nameField: this.getRerPoiTrait("nameField"),
       domainIdField: this.getRerPoiTrait("domainIdField")
     });
     return dataSource;

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -381,7 +381,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
 
     this.attachCurrentViewerListener();
     this.queueDynamicReload(true);
-    void this.preloadServiceQueryableValues();
   }
 
   private stopDynamicViewportRequests() {
@@ -683,6 +682,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
           this.buildLiveEntityMap(ds);
           this.activeDynamicQuery = nextQuery;
           this.isFirstDynamicLoad = false;
+          await this.preloadServiceQueryableValues();
           this.syncCachedEntityVisibility(nextQuery);
           this.updateEnumValues();
           this.sanitizeQueryValues();

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -39,6 +39,10 @@ interface EsriJsonQueryOptions {
   bbox?: Rectangle;
   minLevelId?: number;
   maxLevelId?: number;
+  outFields?: string;
+  orderByFields?: string;
+  returnDistinctValues?: boolean;
+  returnGeometry?: boolean;
 }
 
 interface DynamicViewportQuery {
@@ -78,6 +82,8 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   private managedDataSource: GeoJsonDataSource | undefined;
   private liveEntityByObjectId = new Map<string, any>();
   private isFirstDynamicLoad = true;
+  private serviceEnumValuesLoadPromise: Promise<void> | undefined;
+  private readonly serviceEnumValues = new Map<string, string[]>();
 
   private readonly onDynamicViewportChanged = () => {
     const isPastLimit = this.isCameraPastTiltLimit();
@@ -151,6 +157,18 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       : (value as RerPoiCatalogItemTraits[T]);
   }
 
+  getEnumValues(propertyName: string): string[] {
+    const queryableProperty = this.queryableProperties?.find(
+      (property) => property.propertyName === propertyName
+    );
+
+    if (queryableProperty?.loadValuesFromService) {
+      return this.serviceEnumValues.get(propertyName) ?? [this.ENUM_ALL_VALUE];
+    }
+
+    return super.getEnumValues(propertyName);
+  }
+
   private startDynamicViewportRequests() {
     if (!this.removeViewerChangedListener) {
       this.removeViewerChangedListener =
@@ -180,6 +198,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
 
     this.attachCurrentViewerListener();
     this.queueDynamicReload(true);
+    void this.preloadServiceQueryableValues();
   }
 
   private stopDynamicViewportRequests() {
@@ -217,6 +236,140 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   private detachCurrentViewerListener() {
     this.removeCesiumCameraChangedListener?.();
     this.removeCesiumCameraChangedListener = undefined;
+  }
+
+  private async preloadServiceQueryableValues(): Promise<void> {
+    const propertiesToLoad = (this.queryableProperties ?? []).filter(
+      (property) =>
+        property.propertyType === "enum" &&
+        property.loadValuesFromService &&
+        !this.serviceEnumValues.has(property.propertyName)
+    );
+
+    if (propertiesToLoad.length === 0) {
+      return;
+    }
+
+    if (this.serviceEnumValuesLoadPromise) {
+      return this.serviceEnumValuesLoadPromise;
+    }
+
+    this.serviceEnumValuesLoadPromise = Promise.allSettled(
+      propertiesToLoad.map(async (property) => {
+        const values = await this.loadQueryableValuesFromService(
+          property.propertyName
+        );
+        this.serviceEnumValues.set(
+          property.propertyName,
+          this.buildEnumValuesFromService(values, property.enumMultiValue)
+        );
+      })
+    )
+      .then((results) => {
+        for (const result of results) {
+          if (result.status === "rejected") {
+            console.warn(
+              "[RerPoiCatalogItem] Failed to preload queryable values from service",
+              result.reason
+            );
+          }
+        }
+
+        this.updateEnumValues();
+        if (this.queryValues) {
+          this.sanitizeQueryValues();
+        }
+      })
+      .finally(() => {
+        this.serviceEnumValuesLoadPromise = undefined;
+      });
+
+    return this.serviceEnumValuesLoadPromise;
+  }
+
+  private async loadQueryableValuesFromService(
+    propertyName: string
+  ): Promise<string[]> {
+    const esriJson = await this.loadEsriJsonFromServer({
+      outFields: propertyName,
+      orderByFields: propertyName,
+      returnDistinctValues: true,
+      returnGeometry: false
+    });
+
+    return (esriJson.features ?? [])
+      .map((feature) => feature.attributes?.[propertyName])
+      .filter((value): value is string | number | boolean => isDefined(value))
+      .map((value) => String(value));
+  }
+
+  private buildEnumValuesFromService(
+    values: string[],
+    enumMultiValue: boolean
+  ): string[] {
+    const normalizedValues = values
+      .filter((value) => value !== this.ENUM_ALL_VALUE)
+      .flatMap((value) =>
+        enumMultiValue ? value.split(",").map((text) => text.trim()) : [value]
+      );
+
+    return [this.ENUM_ALL_VALUE, ...Array.from(new Set(normalizedValues))];
+  }
+
+  private async loadEsriJsonFromServer(
+    queryOptions?: EsriJsonQueryOptions
+  ): Promise<EsriJsonFeatureServerResponse> {
+    const supportsPagination = this.supportsPagination;
+    const featuresPerRequest = this.featuresPerRequest;
+    const maxFeatures = this.maxFeatures;
+    const objectIdField = this.objectIdField;
+
+    const fetchPage = async (
+      resultOffset?: number
+    ): Promise<EsriJsonFeatureServerResponse> => {
+      const urlString = runInAction(() =>
+        this.buildEsriJsonUrl({ ...queryOptions, resultOffset })
+      );
+      return loadJson(urlString);
+    };
+
+    const getObjectId = (feature: any): string | undefined =>
+      feature.attributes?.[objectIdField] ??
+      feature.attributes?.OBJECTID ??
+      feature.attributes?.objectid;
+
+    const extractIds = (features: any[]): string[] =>
+      features.map(getObjectId).filter((id): id is string => isDefined(id));
+
+    if (!supportsPagination) {
+      return fetchPage();
+    }
+
+    const combined = await fetchPage(0);
+    combined.features ??= [];
+
+    const seenIDs = new Set<string>(extractIds(combined.features));
+    let currentOffset = 0;
+    let exceededTransferLimit = combined.exceededTransferLimit === true;
+
+    while (exceededTransferLimit) {
+      currentOffset += featuresPerRequest;
+      const page = await fetchPage(currentOffset);
+      const pageFeatures = page.features ?? [];
+      if (!pageFeatures.length) break;
+
+      const newIds = extractIds(pageFeatures);
+      if (newIds.length > 0 && newIds.every((id) => seenIDs.has(id))) break;
+
+      if (combined.features.length + pageFeatures.length > maxFeatures)
+        throw new Error("RerPoi query exceeded the maximum feature limit");
+
+      newIds.forEach((id) => seenIDs.add(id));
+      combined.features = combined.features.concat(pageFeatures);
+      exceededTransferLimit = page.exceededTransferLimit === true;
+    }
+
+    return combined;
   }
 
   private isCameraPastTiltLimit(): boolean {
@@ -581,77 +734,14 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   ): Promise<
     FeatureCollectionWithCrs<Geometry | GeometryCollection, Properties>
   > {
-    const supportsPagination = this.supportsPagination;
-    const featuresPerRequest = this.featuresPerRequest;
-    const maxFeatures = this.maxFeatures;
-    const objectIdField = this.objectIdField;
+    const combined = await this.loadEsriJsonFromServer(queryOptions);
 
-    const fetchPage = async (
-      resultOffset?: number
-    ): Promise<EsriJsonFeatureServerResponse> => {
-      const urlString = runInAction(() =>
-        this.buildEsriJsonUrl({ ...queryOptions, resultOffset })
-      );
-      return loadJson(urlString);
-    };
-
-    const getObjectId = (feature: any): string | undefined =>
-      feature.attributes?.[objectIdField] ??
-      feature.attributes?.OBJECTID ??
-      feature.attributes?.objectid;
-
-    const extractIds = (features: any[]): string[] =>
-      features.map(getObjectId).filter((id): id is string => isDefined(id));
-
-    if (!supportsPagination) {
-      const page = await fetchPage();
-      const count = page.features?.length ?? 0;
-
-      if (count === 0) throw new Error("RerPoi query returned no features");
-      if (count > maxFeatures)
-        throw new Error("RerPoi query exceeded the maximum feature limit");
-      if (page.exceededTransferLimit === true)
-        throw new Error("RerPoi query exceeded transfer limit");
-
-      return (featureDataToGeoJson(page) ?? {
-        type: "FeatureCollection",
-        features: []
-      }) as any;
-    }
-
-    const combined = await fetchPage(0);
-    combined.features ??= [];
-
-    if (combined.features.length === 0)
+    if (!combined.features || combined.features.length === 0)
       throw new Error("RerPoi query returned no features");
-    if (combined.features.length > maxFeatures)
+    if (combined.features.length > this.maxFeatures)
       throw new Error("RerPoi query exceeded the maximum feature limit");
-
-    const seenIDs = new Set<string>(extractIds(combined.features));
-    let currentOffset = 0;
-    let exceededTransferLimit = combined.exceededTransferLimit === true;
-
-    while (exceededTransferLimit) {
-      currentOffset += featuresPerRequest;
-      const page = await fetchPage(currentOffset);
-      const pageFeatures = page.features ?? [];
-      if (!pageFeatures.length) break;
-
-      const newIds = extractIds(pageFeatures);
-      if (newIds.length > 0 && newIds.every((id) => seenIDs.has(id))) break;
-
-      if (combined.features.length + pageFeatures.length > maxFeatures)
-        throw new Error("RerPoi query exceeded the maximum feature limit");
-
-      newIds.forEach((id) => seenIDs.add(id));
-      combined.features = combined.features.concat(pageFeatures);
-      exceededTransferLimit = page.exceededTransferLimit === true;
-    }
-
-    if (combined.features.length === 0)
-      throw new Error("RerPoi query returned no features");
-    if (combined.features.length > maxFeatures)
-      throw new Error("RerPoi query exceeded the maximum feature limit");
+    if (combined.exceededTransferLimit === true)
+      throw new Error("RerPoi query exceeded transfer limit");
 
     return (featureDataToGeoJson(combined) ?? {
       type: "FeatureCollection",
@@ -689,8 +779,13 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       .segment("query")
       .addQuery("f", "json")
       .addQuery("where", combinedWhere || "1=1")
-      .addQuery("outFields", "*")
       .addQuery("outSR", "4326");
+
+    uri.addQuery("outFields", queryOptions?.outFields ?? "*");
+
+    if (queryOptions?.returnDistinctValues) {
+      uri.addQuery("returnDistinctValues", "true");
+    }
 
     if (queryOptions?.bbox) {
       uri
@@ -699,6 +794,17 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         .addQuery("inSR", "4326")
         .addQuery("spatialRel", "esriSpatialRelIntersects")
         .addQuery("returnGeometry", "true");
+    } else if (queryOptions?.returnGeometry !== undefined) {
+      uri.addQuery(
+        "returnGeometry",
+        queryOptions.returnGeometry ? "true" : "false"
+      );
+    } else if (queryOptions?.returnDistinctValues) {
+      uri.addQuery("returnGeometry", "false");
+    }
+
+    if (queryOptions?.orderByFields) {
+      uri.addQuery("orderByFields", queryOptions.orderByFields);
     }
 
     if (queryOptions?.resultOffset !== undefined) {

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -176,7 +176,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       return this.serviceEnumValues.get(propertyName) ?? [this.ENUM_ALL_VALUE];
     }
 
-    const visibleValues = super.getEnumValues(propertyName);
+    const baseValues = this.getLoadedEnumValues(propertyName);
+    const valuesFromData =
+      baseValues.length > 0 ? baseValues : super.getEnumValues(propertyName);
     const preservedValues = (this.queryValues?.[propertyName] ?? []).flatMap(
       (value) =>
         queryableProperty?.enumMultiValue
@@ -186,7 +188,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
 
     const combinedValues = Array.from(
       new Set(
-        [...visibleValues, ...preservedValues].filter(
+        [...valuesFromData, ...preservedValues].filter(
           (value) => isDefined(value) && value.length > 0
         )
       )
@@ -259,6 +261,36 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         );
       this.onDynamicViewportChanged();
     }
+  }
+
+  private getLoadedEnumValues(propertyName: string): string[] {
+    const queryableProperty = this.queryableProperties?.find(
+      (property) => property.propertyName === propertyName
+    );
+    if (!queryableProperty || !this.managedDataSource) return [];
+
+    const now = JulianDate.now();
+    const values = new Set<string>();
+
+    for (const entity of this.managedDataSource.entities.values) {
+      const rawValue = entity.properties?.[propertyName]?.getValue(now);
+      if (!isDefined(rawValue)) continue;
+
+      if (queryableProperty.enumMultiValue) {
+        String(rawValue)
+          .split(",")
+          .map((text) => text.trim())
+          .filter((text) => text.length > 0 && text !== this.ENUM_ALL_VALUE)
+          .forEach((text) => values.add(text));
+      } else {
+        const normalized = String(rawValue).trim();
+        if (normalized && normalized !== this.ENUM_ALL_VALUE) {
+          values.add(normalized);
+        }
+      }
+    }
+
+    return [this.ENUM_ALL_VALUE, ...Array.from(values)];
   }
 
   private detachCurrentViewerListener() {
@@ -598,17 +630,22 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     const entityProperties = entity.properties?.getValue(now);
     if (!entityProperties) return false;
 
+    const normalizeSelectedValues = (values: string[] | undefined): string[] =>
+      (values ?? [])
+        .map((selectedValue) => selectedValue.trim().toLowerCase())
+        .filter(
+          (selectedValue) =>
+            selectedValue !== "" &&
+            selectedValue !== this.ENUM_ALL_VALUE.toLowerCase()
+        );
+
     return Object.entries(this.queryValues).every(([key, value]) => {
       const property = this.queryProperties?.[key];
       if (!property) return true;
 
       if (!entity.properties?.hasProperty(key)) return false;
 
-      const queryValue = (value?.[0] ?? "").trim().toLowerCase();
-      if (queryValue === "" || queryValue === this.ENUM_ALL_VALUE) {
-        return true;
-      }
-
+      const selectedValues = normalizeSelectedValues(value);
       const entityValue = entityProperties[key];
       if (entityValue === undefined || entityValue === null) return false;
 
@@ -623,12 +660,28 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         );
       }
 
-      const entityText = String(entityValue).trim().toLowerCase();
-      if (property.type === "enum" && property.enumMultiValue) {
-        return entityText.includes(queryValue);
+      if (selectedValues.length === 0) {
+        return true;
       }
 
-      return entityText === queryValue;
+      const entityText = String(entityValue).trim().toLowerCase();
+      if (property.type === "enum") {
+        if (property.enumMultiValue) {
+          const entityValues = entityText
+            .split(",")
+            .map((text) => text.trim())
+            .filter((text) => text.length > 0);
+          return selectedValues.some((selectedValue) =>
+            entityValues.includes(selectedValue)
+          );
+        }
+
+        return selectedValues.some(
+          (selectedValue) => entityText === selectedValue
+        );
+      }
+
+      return entityText === selectedValues[0];
     });
   }
 

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -104,6 +104,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   private removeLeafletViewportChangedListener: (() => void) | undefined;
   private removeBeforeViewerChangedListener: (() => void) | undefined;
   private removeViewerChangedListener: (() => void) | undefined;
+  private removeCurrentViewerReaction: (() => void) | undefined;
   private removeViewerModeReaction: (() => void) | undefined;
   private removeShowReaction: (() => void) | undefined;
   private removeLanguageChangedListener: (() => void) | undefined;
@@ -288,8 +289,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   }
 
   private keepImperativeComputedViewsAlive() {
-    // These inherited computed trait views are read by imperative workbench
-    // and viewport reload paths, not only by MobX reactions.
     [
       "disableZoomTo",
       "queryProperties",
@@ -351,14 +350,22 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     if (!this.removeViewerChangedListener) {
       this.removeViewerChangedListener =
         this.terria.mainViewer.afterViewerChanged.addEventListener(() => {
-          this.attachCurrentViewerListener();
-          this.queueDynamicReload(true);
+          this.refreshDynamicViewportRequestsForViewerChange();
         });
     }
 
+    this.removeCurrentViewerReaction ??= reaction(
+      () => this.terria.currentViewer,
+      () => {
+        this.refreshDynamicViewportRequestsForViewerChange();
+      }
+    );
+
     this.removeViewerModeReaction ??= reaction(
       () => this.terria.mainViewer.viewerMode,
-      () => this.queueDynamicReload(true)
+      () => {
+        this.refreshDynamicViewportRequestsForViewerChange();
+      }
     );
 
     if (!this.removeLanguageChangedListener) {
@@ -379,8 +386,32 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       }
     );
 
+    this.refreshDynamicViewportRequestsForViewerChange();
+  }
+
+  private refreshDynamicViewportRequestsForViewerChange() {
+    this.resetDynamicViewportState();
     this.attachCurrentViewerListener();
     this.queueDynamicReload(true);
+  }
+
+  private resetDynamicViewportState() {
+    if (this.dynamicReloadTimer) {
+      clearTimeout(this.dynamicReloadTimer);
+      this.dynamicReloadTimer = undefined;
+    }
+
+    this.dynamicReloadQueued = false;
+    this.dynamicReloadInProgress = false;
+    this.managedDataSource = undefined;
+    this.liveEntityByObjectId.clear();
+    this.isFirstDynamicLoad = true;
+    this.pendingDynamicQuery = undefined;
+    this.activeDynamicQuery = undefined;
+
+    runInAction(() => {
+      this.debugDataSource = undefined;
+    });
   }
 
   private stopDynamicViewportRequests() {
@@ -393,6 +424,8 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     this.removeBeforeViewerChangedListener = undefined;
     this.removeViewerChangedListener?.();
     this.removeViewerChangedListener = undefined;
+    this.removeCurrentViewerReaction?.();
+    this.removeCurrentViewerReaction = undefined;
     this.removeViewerModeReaction?.();
     this.removeViewerModeReaction = undefined;
 
@@ -752,7 +785,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       this.numberOfTotalElements = totalPoiCount;
       this.numberOfVisibleElements = visiblePoiCount;
     });
-
     this.terria.currentViewer.notifyRepaintRequired();
   }
 
@@ -1136,7 +1168,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     return undefined;
   }
 
-  // --- NEW CORE LOGIC: Dynamically calculate accurate rectangle based on literal screen pixels ---
   private getScreenBoundingBox(): Rectangle {
     const currentView = this.terria.currentViewer.getCurrentCameraView();
     const cesium = this.terria.cesium;
@@ -1155,7 +1186,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     const w = canvas.clientWidth;
     const h = canvas.clientHeight;
 
-    // Sample a 3x3 grid across the screen to accurately trace the visible Earth surface
     const screenPoints = [
       new Cartesian2(0, 0),
       new Cartesian2(w / 2, 0),
@@ -1188,22 +1218,17 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       }
     }
 
-    // If all 9 points successfully hit the globe, we have a geometrically perfect bounding box.
     if (validPoints === screenPoints.length) {
-      // Safety check to prevent wrap-around bugs if zoomed out near the poles or antimeridian
       if (maxLon - minLon < Math.PI) {
         return new Rectangle(minLon, minLat, maxLon, maxLat);
       }
     }
 
-    // Fallback: if the camera is pitched such that some rays miss the Earth (e.g. sky is visible),
-    // use Cesium's internal View Frustum calculator. It safely handles horizon calculations.
     const nativeRect = camera.computeViewRectangle(ellipsoid);
     if (nativeRect) {
       return nativeRect;
     }
 
-    // Absolute fallback to Terria's basic cache
     return currentView.rectangle;
   }
 
@@ -1262,7 +1287,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       return undefined;
     }
 
-    // Inject our new precision screen calculating method here
     const screenRectangle = this.getScreenBoundingBox();
     const paddingRatio = this.getRerPoiTrait("queryBboxPaddingRatio");
     const queryRectangle = rectangleWithPadding(screenRectangle, paddingRatio);
@@ -1345,8 +1369,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
 
     const scale = this.terria.mainViewer.scale;
     if (isDefined(scale) && Number.isFinite(scale)) {
-      // Existing scale is in "hundreds of meters" units:
-      // 639 -> 63.9 km -> 63,900 m
       return scale * 100;
     }
 

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -615,6 +615,10 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   }
 
   private isProtectedLevelId(entity: any, now: JulianDate): boolean {
+    if (this.hasActiveFilters()) {
+      return false;
+    }
+
     const levelIdField = this.getRerPoiTrait("levelIdField");
     if (!levelIdField) return false;
 
@@ -622,6 +626,14 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     if (!isDefined(raw)) return false;
 
     return Number(raw) === 7;
+  }
+
+  private hasActiveFilters(): boolean {
+    if (!this.queryValues) return false;
+
+    return Object.values(this.queryValues)
+      .flat()
+      .some((value) => value !== "" && value !== this.ENUM_ALL_VALUE);
   }
 
   private readObjectIdFromEntity(

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -269,6 +269,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     if (!query || !this.managedDataSource) return;
     const now = JulianDate.now();
     const { minLevelId, maxLevelId } = query.requestOptions;
+    let visiblePoiCount = 0;
     for (const entity of this.liveEntityByObjectId.values()) {
       const inRectangle = isEntityInRectangle(entity, query.queryRectangle);
       const inLevelRange = this.isEntityInLevelRange(
@@ -277,8 +278,18 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         minLevelId,
         maxLevelId
       );
-      entity.show = inRectangle && inLevelRange;
+      const isVisible = inRectangle && inLevelRange;
+      entity.show = isVisible;
+      if (isVisible) visiblePoiCount += 1;
     }
+
+    console.log("[RerPoiCatalogItem] POI debug", {
+      cachedPoiCount: this.liveEntityByObjectId.size,
+      visiblePoiCount,
+      cameraHeight: this.getCurrentCameraHeight(),
+      minLevelId,
+      maxLevelId
+    });
   }
 
   private isEntityInLevelRange(

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -1050,7 +1050,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     }
 
     geodesic.setEndPoints(leftCartographic, rightCartographic);
-    return geodesic.surfaceDistance * 100;
+    return geodesic.surfaceDistance;
   }
 
   private getLeafletViewerScale(): number | undefined {

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -238,10 +238,12 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
           this.isFirstDynamicLoad = false;
           this.syncCachedEntityVisibility(nextQuery);
           this.updateEnumValues();
+          this.sanitizeQueryValues();
         }
       } else {
         await this.applyIncrementalUpdate(nextQuery);
         this.updateEnumValues();
+        this.sanitizeQueryValues();
       }
     } finally {
       this.dynamicReloadInProgress = false;

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -20,6 +20,7 @@ import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantPropert
 import SceneMode from "terriajs-cesium/Source/Scene/SceneMode";
 import URI from "urijs";
 import i18next from "i18next";
+import ViewerMode from "../../ViewerMode";
 import isDefined from "../../../Core/isDefined";
 import loadJson from "../../../Core/loadJson";
 import { networkRequestError } from "../../../Core/TerriaError";
@@ -587,6 +588,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       );
 
       applyRerPoiEntityStyles(ds, newEntities, {
+        isCesium2D: this.terria.mainViewer.viewerMode === ViewerMode.Cesium2D,
         defaultMarkerColor: this.getRerPoiTrait("defaultMarkerColor"),
         markerSize: this.getRerPoiTrait("markerSize"),
         iconStrokeWidth: this.getRerPoiTrait("iconStrokeWidth"),
@@ -646,6 +648,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     const dataSource = await super.loadGeoJsonDataSource(geoJson as any);
 
     applyRerPoiEntityStyles(dataSource, dataSource.entities.values, {
+      isCesium2D: this.terria.mainViewer.viewerMode === ViewerMode.Cesium2D,
       defaultMarkerColor: this.getRerPoiTrait("defaultMarkerColor"),
       markerSize: this.getRerPoiTrait("markerSize"),
       iconStrokeWidth: this.getRerPoiTrait("iconStrokeWidth"),

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -16,6 +16,8 @@ import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import EllipsoidGeodesic from "terriajs-cesium/Source/Core/EllipsoidGeodesic";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantProperty";
+import SceneMode from "terriajs-cesium/Source/Scene/SceneMode";
 import URI from "urijs";
 import i18next from "i18next";
 import isDefined from "../../../Core/isDefined";
@@ -68,7 +70,10 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   readonly traits = RerPoiCatalogItemTraits.traits;
 
   private removeCesiumCameraChangedListener: (() => void) | undefined;
+  private removeLeafletViewportChangedListener: (() => void) | undefined;
+  private removeBeforeViewerChangedListener: (() => void) | undefined;
   private removeViewerChangedListener: (() => void) | undefined;
+  private removeViewerModeReaction: (() => void) | undefined;
   private removeShowReaction: (() => void) | undefined;
   private removeLanguageChangedListener: (() => void) | undefined;
 
@@ -170,6 +175,13 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   }
 
   private startDynamicViewportRequests() {
+    if (!this.removeBeforeViewerChangedListener) {
+      this.removeBeforeViewerChangedListener =
+        this.terria.mainViewer.beforeViewerChanged.addEventListener(() => {
+          this.detachCurrentViewerListener();
+        });
+    }
+
     if (!this.removeViewerChangedListener) {
       this.removeViewerChangedListener =
         this.terria.mainViewer.afterViewerChanged.addEventListener(() => {
@@ -177,6 +189,11 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
           this.queueDynamicReload(true);
         });
     }
+
+    this.removeViewerModeReaction ??= reaction(
+      () => this.terria.mainViewer.viewerMode,
+      () => this.queueDynamicReload(true)
+    );
 
     if (!this.removeLanguageChangedListener) {
       i18next.on("languageChanged", this.onLanguageChanged);
@@ -206,8 +223,12 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     this.removeLanguageChangedListener = undefined;
     this.removeShowReaction?.();
     this.removeShowReaction = undefined;
+    this.removeBeforeViewerChangedListener?.();
+    this.removeBeforeViewerChangedListener = undefined;
     this.removeViewerChangedListener?.();
     this.removeViewerChangedListener = undefined;
+    this.removeViewerModeReaction?.();
+    this.removeViewerModeReaction = undefined;
 
     if (this.dynamicReloadTimer) {
       clearTimeout(this.dynamicReloadTimer);
@@ -223,6 +244,8 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     this.managedDataSource = undefined;
     this.liveEntityByObjectId.clear();
     this.isFirstDynamicLoad = true;
+    this.pendingDynamicQuery = undefined;
+    this.activeDynamicQuery = undefined;
   }
 
   private attachCurrentViewerListener() {
@@ -234,12 +257,29 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
           this.onDynamicViewportChanged
         );
       this.onDynamicViewportChanged();
+      return;
+    }
+
+    const leaflet = this.terria.leaflet;
+    if (leaflet) {
+      const map = leaflet.map;
+      map.on("move", this.onDynamicViewportChanged);
+      map.on("zoom", this.onDynamicViewportChanged);
+      map.on("resize", this.onDynamicViewportChanged);
+      this.removeLeafletViewportChangedListener = () => {
+        map.off("move", this.onDynamicViewportChanged);
+        map.off("zoom", this.onDynamicViewportChanged);
+        map.off("resize", this.onDynamicViewportChanged);
+      };
+      this.onDynamicViewportChanged();
     }
   }
 
   private detachCurrentViewerListener() {
     this.removeCesiumCameraChangedListener?.();
     this.removeCesiumCameraChangedListener = undefined;
+    this.removeLeafletViewportChangedListener?.();
+    this.removeLeafletViewportChangedListener = undefined;
   }
 
   private isCameraPastTiltLimit(): boolean {
@@ -364,7 +404,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       const isVisible =
         this.isProtectedLevelId(entity, now) ||
         (inRectangle && inLevelRange && matchesQueryableFilters);
-      entity.show = isVisible;
+      this.setEntityVisibility(entity, isVisible);
       if (isVisible) visiblePoiCount += 1;
     }
     console.log("[RerPoiCatalogItem] POI debug", {
@@ -379,6 +419,14 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     this.numberOfVisibleElements = visiblePoiCount;
 
     this.terria.currentViewer.notifyRepaintRequired();
+  }
+
+  private setEntityVisibility(entity: any, isVisible: boolean) {
+    entity.show = isVisible;
+    const show = new ConstantProperty(isVisible);
+    if (entity.billboard) entity.billboard.show = show;
+    if (entity.point) entity.point.show = show;
+    if (entity.label) entity.label.show = show;
   }
 
   private isEntityInLevelRange(
@@ -499,7 +547,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     }
 
     const newFeatures = (geoJson.features ?? []) as any[];
-    if (newFeatures.length === 0) return;
 
     const pruneRect = rectangleWithPadding(nextQuery.queryRectangle, 0.5);
     const now = JulianDate.now();
@@ -647,7 +694,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       const page = await fetchPage();
       const count = page.features?.length ?? 0;
 
-      if (count === 0) throw new Error("RerPoi query returned no features");
       if (count > maxFeatures)
         throw new Error("RerPoi query exceeded the maximum feature limit");
       if (page.exceededTransferLimit === true)
@@ -662,8 +708,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     const combined = await fetchPage(0);
     combined.features ??= [];
 
-    if (combined.features.length === 0)
-      throw new Error("RerPoi query returned no features");
     if (combined.features.length > maxFeatures)
       throw new Error("RerPoi query exceeded the maximum feature limit");
 
@@ -688,8 +732,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       exceededTransferLimit = page.exceededTransferLimit === true;
     }
 
-    if (combined.features.length === 0)
-      throw new Error("RerPoi query returned no features");
     if (combined.features.length > maxFeatures)
       throw new Error("RerPoi query exceeded the maximum feature limit");
 
@@ -776,6 +818,11 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     const camera = scene.camera;
     const canvas = scene.canvas;
     const ellipsoid = scene.globe.ellipsoid;
+
+    if (scene.mode === SceneMode.SCENE2D) {
+      const rect = camera.computeViewRectangle(ellipsoid);
+      return rect ?? currentView.rectangle;
+    }
 
     const w = canvas.clientWidth;
     const h = canvas.clientHeight;
@@ -960,6 +1007,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   }
 
   private getCurrentViewerScale(): number | undefined {
+    const leafletScale = this.getLeafletViewerScale();
+    if (isDefined(leafletScale)) return leafletScale;
+
     const scale = this.terria.mainViewer.scale;
     if (isDefined(scale) && Number.isFinite(scale)) {
       // Existing scale is in "hundreds of meters" units:
@@ -1000,7 +1050,24 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     }
 
     geodesic.setEndPoints(leftCartographic, rightCartographic);
-    return geodesic.surfaceDistance;
+    return geodesic.surfaceDistance * 100;
+  }
+
+  private getLeafletViewerScale(): number | undefined {
+    const leaflet = this.terria.leaflet;
+    if (!leaflet) return undefined;
+
+    const map = leaflet.map;
+    const size = map.getSize();
+    if (size.x <= 1 || size.y <= 1) return undefined;
+
+    const y = size.y / 2;
+    const x = size.x / 2;
+    const pixelDistance = map
+      .containerPointToLatLng([x, y])
+      .distanceTo(map.containerPointToLatLng([x + 1, y]));
+
+    return Number.isFinite(pixelDistance) ? pixelDistance * 100 : undefined;
   }
 }
 

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -237,9 +237,11 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
           this.activeDynamicQuery = nextQuery;
           this.isFirstDynamicLoad = false;
           this.syncCachedEntityVisibility(nextQuery);
+          this.updateEnumValues();
         }
       } else {
         await this.applyIncrementalUpdate(nextQuery);
+        this.updateEnumValues();
       }
     } finally {
       this.dynamicReloadInProgress = false;

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -362,7 +362,14 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       entity.show = isVisible;
       if (isVisible) visiblePoiCount += 1;
     }
-
+    console.log("[RerPoiCatalogItem] POI debug", {
+      cachedPoiCount: this.liveEntityByObjectId.size,
+      visiblePoiCount,
+      totalPoiCount,
+      cameraHeight: this.getCurrentCameraHeight(),
+      minLevelId,
+      maxLevelId
+    });
     this.numberOfTotalElements = totalPoiCount;
     this.numberOfVisibleElements = visiblePoiCount;
 

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -9,6 +9,7 @@ import {
   observable,
   makeObservable
 } from "mobx";
+import { keepAlive } from "mobx-utils";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
@@ -63,6 +64,31 @@ interface EsriJsonFeatureServerResponse {
   exceededTransferLimit?: boolean;
 }
 
+interface RerPoiTraitSnapshot {
+  cameraTiltLimitDegrees: number;
+  defaultMarkerColor: string;
+  domainIdField: string;
+  dynamicRequestDebounceMs: number;
+  iconStrokeColor: string;
+  iconStrokeWidth: number;
+  labelFontSize: number;
+  labelOutlineColor: string;
+  labelOutlineWidth: number;
+  labelTextColor: string;
+  levelIdField: string;
+  levelIdMappings: LevelIdCameraHeightMapping[];
+  markerSize: number;
+  minLevelId: number;
+  nameField: string;
+  poiDomainStyleGroups: RerPoiCatalogItemTraits["poiDomainStyleGroups"];
+  queryableProperties: RerPoiCatalogItemTraits["queryableProperties"];
+  queryBboxPaddingRatio: number;
+  scaleField: string;
+  showDebugBBox: boolean;
+  showLabels: boolean;
+  where: string;
+}
+
 export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   static readonly type = RER_POI_CATALOG_ITEM_TYPE;
   static readonly TraitsClass = RerPoiCatalogItemTraits;
@@ -75,6 +101,8 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   private removeViewerChangedListener: (() => void) | undefined;
   private removeShowReaction: (() => void) | undefined;
   private removeLanguageChangedListener: (() => void) | undefined;
+  private removeTraitSnapshotReaction: (() => void) | undefined;
+  private readonly computedKeepAliveDisposers: Array<() => void> = [];
 
   private dynamicReloadTimer: ReturnType<typeof setTimeout> | undefined;
   private pendingDynamicQuery: DynamicViewportQuery | undefined;
@@ -85,6 +113,8 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   @observable private cameraTiltLimitExceeded = false;
   @observable private activeLanguage =
     i18next.resolvedLanguage ?? i18next.language;
+  @observable.ref private rerPoiTraitSnapshot =
+    createDefaultRerPoiTraitSnapshot();
 
   private managedDataSource: GeoJsonDataSource | undefined;
   private liveEntityByObjectId = new Map<string, any>();
@@ -127,6 +157,17 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     onBecomeUnobserved(this, "mapItems", () =>
       this.stopDynamicViewportRequests()
     );
+
+    this.keepImperativeComputedViewsAlive();
+    this.keepImperativeTraitSnapshotUpdated();
+  }
+
+  dispose() {
+    super.dispose();
+    this.stopDynamicViewportRequests();
+    this.removeTraitSnapshotReaction?.();
+    this.removeTraitSnapshotReaction = undefined;
+    this.disposeImperativeComputedViews();
   }
 
   @override
@@ -175,18 +216,91 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     return report;
   }
 
-  private getRerPoiTrait<T extends keyof RerPoiCatalogItemTraits>(
+  private getRerPoiTrait<T extends keyof RerPoiTraitSnapshot>(
+    traitName: T
+  ): RerPoiTraitSnapshot[T] {
+    return this.rerPoiTraitSnapshot[traitName];
+  }
+
+  private getRerPoiTraitForSnapshot<T extends keyof RerPoiCatalogItemTraits>(
     traitName: T
   ): RerPoiCatalogItemTraits[T] {
     const trait = RerPoiCatalogItemTraits.traits[traitName as string];
     const value = trait?.getValue(this as unknown as BaseModel);
-    return value === undefined
-      ? defaultRerPoiCatalogItemTraits[traitName]
-      : (value as RerPoiCatalogItemTraits[T]);
+    return cloneTraitValue(
+      value === undefined ? defaultRerPoiCatalogItemTraits[traitName] : value
+    ) as RerPoiCatalogItemTraits[T];
+  }
+
+  private buildRerPoiTraitSnapshot(): RerPoiTraitSnapshot {
+    return {
+      cameraTiltLimitDegrees: this.getRerPoiTraitForSnapshot(
+        "cameraTiltLimitDegrees"
+      ),
+      defaultMarkerColor: this.getRerPoiTraitForSnapshot("defaultMarkerColor"),
+      domainIdField: this.getRerPoiTraitForSnapshot("domainIdField"),
+      dynamicRequestDebounceMs: this.getRerPoiTraitForSnapshot(
+        "dynamicRequestDebounceMs"
+      ),
+      iconStrokeColor: this.getRerPoiTraitForSnapshot("iconStrokeColor"),
+      iconStrokeWidth: this.getRerPoiTraitForSnapshot("iconStrokeWidth"),
+      labelFontSize: this.getRerPoiTraitForSnapshot("labelFontSize"),
+      labelOutlineColor: this.getRerPoiTraitForSnapshot("labelOutlineColor"),
+      labelOutlineWidth: this.getRerPoiTraitForSnapshot("labelOutlineWidth"),
+      labelTextColor: this.getRerPoiTraitForSnapshot("labelTextColor"),
+      levelIdField: this.getRerPoiTraitForSnapshot("levelIdField"),
+      levelIdMappings: this.getRerPoiTraitForSnapshot("levelIdMappings"),
+      markerSize: this.getRerPoiTraitForSnapshot("markerSize"),
+      minLevelId: this.getRerPoiTraitForSnapshot("minLevelId"),
+      nameField: this.getRerPoiTraitForSnapshot("nameField"),
+      poiDomainStyleGroups: this.getRerPoiTraitForSnapshot(
+        "poiDomainStyleGroups"
+      ),
+      queryableProperties:
+        this.getRerPoiTraitForSnapshot("queryableProperties"),
+      queryBboxPaddingRatio: this.getRerPoiTraitForSnapshot(
+        "queryBboxPaddingRatio"
+      ),
+      scaleField: this.getRerPoiTraitForSnapshot("scaleField"),
+      showDebugBBox: this.getRerPoiTraitForSnapshot("showDebugBBox"),
+      showLabels: this.getRerPoiTraitForSnapshot("showLabels"),
+      where: this.getRerPoiTraitForSnapshot("where")
+    };
+  }
+
+  private keepImperativeTraitSnapshotUpdated() {
+    this.removeTraitSnapshotReaction = reaction(
+      () => this.buildRerPoiTraitSnapshot(),
+      (snapshot) => {
+        runInAction(() => {
+          this.rerPoiTraitSnapshot = snapshot;
+        });
+      },
+      { fireImmediately: true }
+    );
+  }
+
+  private keepImperativeComputedViewsAlive() {
+    // These inherited computed trait views are read by imperative workbench
+    // and viewport reload paths, not only by MobX reactions.
+    [
+      "disableZoomTo",
+      "queryProperties",
+      "queryableProperties",
+      "where",
+      "zoomOnAddToWorkbench"
+    ].forEach((property) => {
+      this.computedKeepAliveDisposers.push(keepAlive(this, property));
+    });
+  }
+
+  private disposeImperativeComputedViews() {
+    this.computedKeepAliveDisposers.forEach((dispose) => dispose());
+    this.computedKeepAliveDisposers.length = 0;
   }
 
   getEnumValues(propertyName: string): string[] {
-    const queryableProperty = this.queryableProperties?.find(
+    const queryableProperty = this.getRerPoiTrait("queryableProperties")?.find(
       (property) => property.propertyName === propertyName
     );
 
@@ -196,7 +310,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
 
     const baseValues = this.getLoadedEnumValues(propertyName);
     const valuesFromData =
-      baseValues.length > 0 ? baseValues : super.getEnumValues(propertyName);
+      baseValues.length > 0
+        ? baseValues
+        : runInAction(() => super.getEnumValues(propertyName));
     const preservedValues = (this.queryValues?.[propertyName] ?? []).flatMap(
       (value) =>
         queryableProperty?.enumMultiValue
@@ -287,7 +403,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   }
 
   private getLoadedEnumValues(propertyName: string): string[] {
-    const queryableProperty = this.queryableProperties?.find(
+    const queryableProperty = this.getRerPoiTrait("queryableProperties")?.find(
       (property) => property.propertyName === propertyName
     );
     if (!queryableProperty || !this.managedDataSource) return [];
@@ -322,7 +438,9 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   }
 
   private async preloadServiceQueryableValues(): Promise<void> {
-    const propertiesToLoad = (this.queryableProperties ?? []).filter(
+    const propertiesToLoad = (
+      this.getRerPoiTrait("queryableProperties") ?? []
+    ).filter(
       (property) =>
         property.propertyType === "enum" &&
         property.loadValuesFromService &&
@@ -588,8 +706,10 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       minLevelId,
       maxLevelId
     });
-    this.numberOfTotalElements = totalPoiCount;
-    this.numberOfVisibleElements = visiblePoiCount;
+    runInAction(() => {
+      this.numberOfTotalElements = totalPoiCount;
+      this.numberOfVisibleElements = visiblePoiCount;
+    });
 
     this.terria.currentViewer.notifyRepaintRequired();
   }
@@ -884,7 +1004,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     }
 
     const combinedWhere = [
-      this.where,
+      this.getRerPoiTrait("where"),
       this.buildLevelFilterClause(
         queryOptions?.minLevelId,
         queryOptions?.maxLevelId
@@ -1112,7 +1232,12 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     return {
       minLevelId,
       maxLevelId,
-      filterKey: [this.where, levelIdField, minLevelId, maxLevelId].join("|")
+      filterKey: [
+        this.getRerPoiTrait("where"),
+        levelIdField,
+        minLevelId,
+        maxLevelId
+      ].join("|")
     };
   }
 
@@ -1189,6 +1314,63 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     geodesic.setEndPoints(leftCartographic, rightCartographic);
     return geodesic.surfaceDistance;
   }
+}
+
+function getDefaultRerPoiTrait<T extends keyof RerPoiCatalogItemTraits>(
+  traitName: T
+): RerPoiCatalogItemTraits[T] {
+  return cloneTraitValue(defaultRerPoiCatalogItemTraits[traitName]);
+}
+
+function createDefaultRerPoiTraitSnapshot(): RerPoiTraitSnapshot {
+  return {
+    cameraTiltLimitDegrees: getDefaultRerPoiTrait("cameraTiltLimitDegrees"),
+    defaultMarkerColor: getDefaultRerPoiTrait("defaultMarkerColor"),
+    domainIdField: getDefaultRerPoiTrait("domainIdField"),
+    dynamicRequestDebounceMs: getDefaultRerPoiTrait(
+      "dynamicRequestDebounceMs"
+    ),
+    iconStrokeColor: getDefaultRerPoiTrait("iconStrokeColor"),
+    iconStrokeWidth: getDefaultRerPoiTrait("iconStrokeWidth"),
+    labelFontSize: getDefaultRerPoiTrait("labelFontSize"),
+    labelOutlineColor: getDefaultRerPoiTrait("labelOutlineColor"),
+    labelOutlineWidth: getDefaultRerPoiTrait("labelOutlineWidth"),
+    labelTextColor: getDefaultRerPoiTrait("labelTextColor"),
+    levelIdField: getDefaultRerPoiTrait("levelIdField"),
+    levelIdMappings: getDefaultRerPoiTrait("levelIdMappings"),
+    markerSize: getDefaultRerPoiTrait("markerSize"),
+    minLevelId: getDefaultRerPoiTrait("minLevelId"),
+    nameField: getDefaultRerPoiTrait("nameField"),
+    poiDomainStyleGroups: getDefaultRerPoiTrait("poiDomainStyleGroups"),
+    queryableProperties: getDefaultRerPoiTrait("queryableProperties"),
+    queryBboxPaddingRatio: getDefaultRerPoiTrait("queryBboxPaddingRatio"),
+    scaleField: getDefaultRerPoiTrait("scaleField"),
+    showDebugBBox: getDefaultRerPoiTrait("showDebugBBox"),
+    showLabels: getDefaultRerPoiTrait("showLabels"),
+    where: getDefaultRerPoiTrait("where")
+  };
+}
+
+function cloneTraitValue<T>(value: T): T {
+  if (value instanceof BaseModel) {
+    return Object.keys(value.traits).reduce((result, traitName) => {
+      result[traitName] = cloneTraitValue((value as any)[traitName]);
+      return result;
+    }, {} as any);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneTraitValue(item)) as T;
+  }
+
+  if (value !== null && typeof value === "object") {
+    return Object.keys(value as any).reduce((result, key) => {
+      result[key] = cloneTraitValue((value as any)[key]);
+      return result;
+    }, {} as any);
+  }
+
+  return value;
 }
 
 function rectangleWithPadding(

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -1,10 +1,13 @@
 import { featureCollection } from "@turf/helpers";
 import { Geometry, GeometryCollection, Properties } from "@turf/helpers";
 import {
+  override,
   onBecomeObserved,
   onBecomeUnobserved,
   reaction,
-  runInAction
+  runInAction,
+  observable,
+  makeObservable
 } from "mobx";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
@@ -12,6 +15,7 @@ import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import URI from "urijs";
+import i18next from "i18next";
 import isDefined from "../../../Core/isDefined";
 import loadJson from "../../../Core/loadJson";
 import { networkRequestError } from "../../../Core/TerriaError";
@@ -59,6 +63,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   private removeCesiumCameraChangedListener: (() => void) | undefined;
   private removeViewerChangedListener: (() => void) | undefined;
   private removeShowReaction: (() => void) | undefined;
+  private removeLanguageChangedListener: (() => void) | undefined;
 
   private dynamicReloadTimer: ReturnType<typeof setTimeout> | undefined;
   private pendingDynamicQuery: DynamicViewportQuery | undefined;
@@ -66,17 +71,32 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
   private dynamicReloadQueued = false;
   private dynamicReloadInProgress = false;
 
+  @observable private cameraTiltLimitExceeded = false;
+  @observable private activeLanguage =
+    i18next.resolvedLanguage ?? i18next.language;
+
   private managedDataSource: GeoJsonDataSource | undefined;
   private liveEntityByObjectId = new Map<string, any>();
   private isFirstDynamicLoad = true;
 
   private readonly onDynamicViewportChanged = () => {
-    if (this.isCameraPastTiltLimit()) return;
+    const isPastLimit = this.isCameraPastTiltLimit();
+    runInAction(() => {
+      this.cameraTiltLimitExceeded = isPastLimit;
+    });
+    if (isPastLimit) return;
     this.queueDynamicReload();
+  };
+
+  private readonly onLanguageChanged = (language: string) => {
+    runInAction(() => {
+      this.activeLanguage = language;
+    });
   };
 
   constructor(...args: ModelConstructorParameters) {
     super(...args);
+    makeObservable(this);
     this.setTrait(CommonStrata.definition, "forceCesiumPrimitives", true);
     this.setTrait(CommonStrata.definition, "clustering", {
       enabled: true,
@@ -103,6 +123,24 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     return stratum?._featureServer?.objectIdField ?? "OBJECTID";
   }
 
+  @override
+  get shortReport(): string | undefined {
+    let report: string = "";
+
+    if (this.cameraTiltLimitExceeded) {
+      const tiltMessage = i18next.t(
+        "models.rerPoiCatalogItem.exceededCameraTiltLimit",
+        {
+          cameraTiltLimitDegrees: this.getRerPoiTrait("cameraTiltLimitDegrees"),
+          lng: this.activeLanguage
+        }
+      );
+      report = report ? `${report}<br/>${tiltMessage}` : tiltMessage;
+    }
+
+    return report;
+  }
+
   private getRerPoiTrait<T extends keyof RerPoiCatalogItemTraits>(
     traitName: T
   ): RerPoiCatalogItemTraits[T] {
@@ -122,6 +160,17 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         });
     }
 
+    if (!this.removeLanguageChangedListener) {
+      i18next.on("languageChanged", this.onLanguageChanged);
+      this.removeLanguageChangedListener = () => {
+        i18next.off("languageChanged", this.onLanguageChanged);
+      };
+    }
+
+    runInAction(() => {
+      this.activeLanguage = i18next.resolvedLanguage ?? i18next.language;
+    });
+
     this.removeShowReaction ??= reaction(
       () => this.show,
       (show) => {
@@ -135,6 +184,8 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
 
   private stopDynamicViewportRequests() {
     this.detachCurrentViewerListener();
+    this.removeLanguageChangedListener?.();
+    this.removeLanguageChangedListener = undefined;
     this.removeShowReaction?.();
     this.removeShowReaction = undefined;
     this.removeViewerChangedListener?.();
@@ -151,7 +202,6 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     this.liveEntityByObjectId.clear();
     this.isFirstDynamicLoad = true;
   }
-
   private attachCurrentViewerListener() {
     this.detachCurrentViewerListener();
     const cesium = this.terria.cesium;
@@ -160,6 +210,7 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         cesium.scene.camera.changed.addEventListener(
           this.onDynamicViewportChanged
         );
+      this.onDynamicViewportChanged();
     }
   }
 

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -166,7 +166,25 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       return this.serviceEnumValues.get(propertyName) ?? [this.ENUM_ALL_VALUE];
     }
 
-    return super.getEnumValues(propertyName);
+    const visibleValues = super.getEnumValues(propertyName);
+    const preservedValues = (this.queryValues?.[propertyName] ?? []).flatMap(
+      (value) =>
+        queryableProperty?.enumMultiValue
+          ? value.split(",").map((text) => text.trim())
+          : [value]
+    );
+
+    const combinedValues = Array.from(
+      new Set(
+        [...visibleValues, ...preservedValues].filter(
+          (value) => isDefined(value) && value.length > 0
+        )
+      )
+    );
+
+    return combinedValues.includes(this.ENUM_ALL_VALUE)
+      ? combinedValues
+      : [this.ENUM_ALL_VALUE, ...combinedValues];
   }
 
   private startDynamicViewportRequests() {

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -144,6 +144,16 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
       report = report ? `${report}<br/>${tiltMessage}` : tiltMessage;
     }
 
+    if (this.show && this.numberOfVisibleElements === 0) {
+      const noVisiblePointsMessage = i18next.t(
+        "models.rerPoiCatalogItem.noVisiblePoints",
+        { lng: this.activeLanguage }
+      );
+      report = report
+        ? `${report}<br/>${noVisiblePointsMessage}`
+        : noVisiblePointsMessage;
+    }
+
     return report;
   }
 

--- a/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/RerPoiCatalogItem.ts
@@ -211,6 +211,8 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         nextQuery.queryRectangle
       )
     ) {
+      this.activeDynamicQuery = nextQuery;
+      this.syncCachedEntityVisibility(nextQuery);
       return;
     }
 
@@ -269,7 +271,10 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     if (!query || !this.managedDataSource) return;
     const now = JulianDate.now();
     const { minLevelId, maxLevelId } = query.requestOptions;
-    for (const entity of this.liveEntityByObjectId.values()) {
+    let visiblePoiCount = 0;
+    const totalPoiCount = this.managedDataSource.entities.values.length;
+
+    for (const entity of this.managedDataSource.entities.values) {
       const inRectangle = isEntityInRectangle(entity, query.queryRectangle);
       const inLevelRange = this.isEntityInLevelRange(
         entity,
@@ -277,8 +282,16 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
         minLevelId,
         maxLevelId
       );
-      entity.show = inRectangle && inLevelRange;
+      const matchesQueryableFilters = this.matchesQueryableFilters(entity, now);
+      const isVisible = inRectangle && inLevelRange && matchesQueryableFilters;
+      entity.show = isVisible;
+      if (isVisible) visiblePoiCount += 1;
     }
+
+    this.numberOfTotalElements = totalPoiCount;
+    this.numberOfVisibleElements = visiblePoiCount;
+
+    this.terria.currentViewer.notifyRepaintRequired();
   }
 
   private isEntityInLevelRange(
@@ -320,6 +333,59 @@ export default class RerPoiCatalogItem extends ArcGisFeatureServerCatalogItem {
     const raw =
       props[this.objectIdField] ?? props["OBJECTID"] ?? props["objectid"];
     return raw !== undefined && raw !== null ? String(raw) : undefined;
+  }
+
+  filterData() {
+    this.syncCachedEntityVisibility(
+      this.activeDynamicQuery ?? this.getDynamicViewportQuery()
+    );
+  }
+
+  private matchesQueryableFilters(entity: any, now: JulianDate): boolean {
+    if (!this.queryProperties || !this.queryValues) return true;
+
+    const selectedValuesArray = Object.values(this.queryValues);
+    const showAll = !selectedValuesArray
+      .flat()
+      .some((value) => value !== "" && value !== this.ENUM_ALL_VALUE);
+
+    if (showAll) return true;
+
+    const entityProperties = entity.properties?.getValue(now);
+    if (!entityProperties) return false;
+
+    return Object.entries(this.queryValues).every(([key, value]) => {
+      const property = this.queryProperties?.[key];
+      if (!property) return true;
+
+      if (!entity.properties?.hasProperty(key)) return false;
+
+      const queryValue = (value?.[0] ?? "").trim().toLowerCase();
+      if (queryValue === "" || queryValue === this.ENUM_ALL_VALUE) {
+        return true;
+      }
+
+      const entityValue = entityProperties[key];
+      if (entityValue === undefined || entityValue === null) return false;
+
+      if (property.type === "date") {
+        if (value[0] === "" || value[1] === "") return true;
+        const fromDate = new Date(value[0]);
+        const toDate = new Date(value[1]);
+        const entityDate = new Date(String(entityValue));
+        return (
+          fromDate.getTime() < entityDate.getTime() &&
+          entityDate.getTime() < toDate.getTime()
+        );
+      }
+
+      const entityText = String(entityValue).trim().toLowerCase();
+      if (property.type === "enum" && property.enumMultiValue) {
+        return entityText.includes(queryValue);
+      }
+
+      return entityText === queryValue;
+    });
   }
 
   private async applyIncrementalUpdate(nextQuery: DynamicViewportQuery) {

--- a/lib/Models/Catalog/registerCatalogMembers.ts
+++ b/lib/Models/Catalog/registerCatalogMembers.ts
@@ -49,6 +49,7 @@ import ArcGisMapServerCatalogItem from "./Esri/ArcGisMapServerCatalogItem";
 import ArcGisPortalCatalogGroup from "./Esri/ArcGisPortalCatalogGroup";
 import ArcGisPortalItemReference from "./Esri/ArcGisPortalItemReference";
 import ArcGisTerrainCatalogItem from "./Esri/ArcGisTerrainCatalogItem";
+import RerPoiCatalogItem from "./Esri/RerPoiCatalogItem";
 import AssImpCatalogItem from "./Gltf/AssImpCatalogItem";
 import GltfCatalogItem from "./Gltf/GltfCatalogItem";
 import GtfsCatalogItem from "./Gtfs/GtfsCatalogItem";
@@ -66,6 +67,10 @@ import WebProcessingServiceCatalogGroup from "./Ows/WebProcessingServiceCatalogG
 import SdmxJsonCatalogGroup from "./SdmxJson/SdmxJsonCatalogGroup";
 import SdmxJsonCatalogItem from "./SdmxJson/SdmxJsonCatalogItem";
 import CogCatalogItem from "./CatalogItems/CogCatalogItem";
+import {
+  isRerPoiUrl,
+  RER_POI_CATALOG_ITEM_TYPE
+} from "../../ModelMixins/RerPoiHelpers";
 
 export default function registerCatalogMembers() {
   CatalogMemberFactory.register(CatalogGroup.type, CatalogGroup);
@@ -121,6 +126,7 @@ export default function registerCatalogMembers() {
     ArcGisFeatureServerCatalogItem.type,
     ArcGisFeatureServerCatalogItem
   );
+  CatalogMemberFactory.register(RerPoiCatalogItem.type, RerPoiCatalogItem);
   CatalogMemberFactory.register(
     ArcGisFeatureServerCatalogGroup.type,
     ArcGisFeatureServerCatalogGroup
@@ -316,6 +322,16 @@ export default function registerCatalogMembers() {
     true
   );
   UrlToCatalogMemberMapping.register(
+    isRerPoiUrl,
+    RER_POI_CATALOG_ITEM_TYPE,
+    true
+  );
+  UrlToCatalogMemberMapping.register(
+    matchesUrl(/\/arcgis\/rest\/.*\/MapServer\/\d+\b/i),
+    ArcGisFeatureServerCatalogItem.type,
+    true
+  );
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/arcgis\/rest\/.*\/MapServer\/\d+\b/i),
     ArcGisMapServerCatalogItem.type,
     true
@@ -348,6 +364,11 @@ export default function registerCatalogMembers() {
   UrlToCatalogMemberMapping.register(
     matchesUrl(/\/arcgis\/rest\//i),
     ArcGisCatalogGroup.type,
+    true
+  );
+  UrlToCatalogMemberMapping.register(
+    matchesUrl(/\/rest\/.*\/MapServer\/\d+\b/i),
+    ArcGisFeatureServerCatalogItem.type,
     true
   );
   UrlToCatalogMemberMapping.register(

--- a/lib/ReactViews/Workbench/Controls/FilterFeaturesSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/FilterFeaturesSection.tsx
@@ -13,6 +13,7 @@ import { GLYPHS, StyledIcon } from "../../../Styled/Icon";
 import Button, { RawButton } from "../../../Styled/Button";
 import Hr from "../../../Styled/Hr";
 import ViewState from "../../../ReactViewModels/ViewState";
+import { RER_POI_CATALOG_ITEM_TYPE } from "../../../ModelMixins/RerPoiHelpers";
 
 interface PropsType {
   item: BaseModel;
@@ -196,7 +197,8 @@ const FilterFeaturesSection: React.FC<PropsType> = observer(
             <Spacing bottom={3} />
             <Box style={{ display: "flex", flexDirection: "row-reverse" }}>
               {viewState.terria.isFeatureAllowedByProfile("QueryData") &&
-                !viewState.useSmallScreenInterface && (
+                !viewState.useSmallScreenInterface &&
+                item.type !== RER_POI_CATALOG_ITEM_TYPE && (
                   <Button
                     primary
                     title="Mostra i dati come grafici e tabelle"

--- a/lib/ReactViews/Workbench/Controls/FilterFeaturesSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/FilterFeaturesSection.tsx
@@ -23,6 +23,7 @@ interface PropsType {
 const FilterFeaturesSection: React.FC<PropsType> = observer(
   ({ item, viewState }: PropsType) => {
     const [showQuerySection, setShowQuerySection] = useState<boolean>(false);
+    const isRerPoiCatalogItem = item.type === RER_POI_CATALOG_ITEM_TYPE;
 
     const toggleQuerySection = () => {
       setShowQuerySection((prevState) => !prevState);
@@ -55,6 +56,8 @@ const FilterFeaturesSection: React.FC<PropsType> = observer(
       item.queryableProperties.length === 0
     )
       return null;
+
+    const queryableItem = item as QueryableCatalogItemMixin.Instance;
 
     return (
       <Box column>
@@ -93,13 +96,108 @@ const FilterFeaturesSection: React.FC<PropsType> = observer(
                   );
                 })
                 .map(([propertyName, property]) => {
+                  const enumValues = (
+                    queryableItem.enumValues?.[propertyName] ?? []
+                  )
+                    .slice()
+                    .sort();
+                  const enumRows = queryableItem.queryValues?.[
+                    propertyName
+                  ] ?? [""];
+
                   return (
                     <Box key={propertyName} styledMargin="0 0 10px 0">
                       <StyledLabel small htmlFor="opacity">
                         {property.label}
                       </StyledLabel>
                       <Spacing right={3} />
-                      {property.type === "enum" && (
+                      {property.type === "enum" && isRerPoiCatalogItem && (
+                        <Box column>
+                          {enumRows.map((rowValue, rowIndex) => {
+                            const selectedValue =
+                              rowValue.trim().length > 0
+                                ? rowValue
+                                : queryableItem.ENUM_ALL_VALUE;
+                            const isLastRow = rowIndex === enumRows.length - 1;
+
+                            return (
+                              <Box
+                                key={`${propertyName}-${rowIndex}`}
+                                styledMargin={
+                                  rowIndex < enumRows.length - 1
+                                    ? "0 0 8px 0"
+                                    : "0"
+                                }
+                                style={{
+                                  display: "flex",
+                                  alignItems: "center"
+                                }}
+                              >
+                                <Select
+                                  boxProps={{
+                                    fullWidth: false,
+                                    flex: 1,
+                                    styledMinWidth: "0"
+                                  }}
+                                  name={`${propertyName}-${rowIndex}`}
+                                  value={selectedValue}
+                                  onChange={(
+                                    e: React.ChangeEvent<HTMLSelectElement>
+                                  ) => {
+                                    runInAction(() => {
+                                      const nextValues = enumRows.slice();
+                                      nextValues[rowIndex] =
+                                        e.target.value ===
+                                        queryableItem.ENUM_ALL_VALUE
+                                          ? ""
+                                          : e.target.value;
+                                      item.setQuery(propertyName, nextValues);
+                                    });
+                                  }}
+                                >
+                                  {enumValues.map((value) => {
+                                    return (
+                                      <option key={value} value={value}>
+                                        {value}
+                                      </option>
+                                    );
+                                  })}
+                                </Select>
+                                {isLastRow &&
+                                  selectedValue !==
+                                    queryableItem.ENUM_ALL_VALUE && (
+                                    <Button
+                                      primary
+                                      title="Aggiungi un altro filtro della stessa categoria"
+                                      css={`
+                                        min-width: 32px;
+                                        height: 34px;
+                                        border-radius: 2px;
+                                        margin-left: 6px;
+                                        padding: 0 8px;
+                                        display: flex;
+                                        align-items: center;
+                                        justify-content: center;
+                                        font-weight: bold;
+                                      `}
+                                      onClick={() =>
+                                        runInAction(() => {
+                                          item.setQuery(propertyName, [
+                                            ...enumRows,
+                                            ""
+                                          ]);
+                                        })
+                                      }
+                                    >
+                                      +
+                                    </Button>
+                                  )}
+                              </Box>
+                            );
+                          })}
+                        </Box>
+                      )}
+                      {property.type === "enum" && !isRerPoiCatalogItem && (
                         <Select
                           name={propertyName}
                           value={item.queryValues?.[propertyName]?.[0]}
@@ -111,16 +209,13 @@ const FilterFeaturesSection: React.FC<PropsType> = observer(
                             });
                           }}
                         >
-                          {(item.enumValues?.[propertyName] ?? [])
-                            .slice()
-                            .sort()
-                            .map((value) => {
-                              return (
-                                <option key={value} value={value}>
-                                  {value}
-                                </option>
-                              );
-                            })}
+                          {enumValues.map((value) => {
+                            return (
+                              <option key={value} value={value}>
+                                {value}
+                              </option>
+                            );
+                          })}
                         </Select>
                       )}
                       {(property.type === "string" ||

--- a/lib/ReactViews/Workbench/Controls/FilterFeaturesSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/FilterFeaturesSection.tsx
@@ -119,6 +119,10 @@ const FilterFeaturesSection: React.FC<PropsType> = observer(
                                 ? rowValue
                                 : queryableItem.ENUM_ALL_VALUE;
                             const isLastRow = rowIndex === enumRows.length - 1;
+                            const showAddButton =
+                              isLastRow &&
+                              selectedValue !== queryableItem.ENUM_ALL_VALUE;
+                            const showRemoveButton = rowIndex > 0;
 
                             return (
                               <Box
@@ -163,35 +167,75 @@ const FilterFeaturesSection: React.FC<PropsType> = observer(
                                     );
                                   })}
                                 </Select>
-                                {isLastRow &&
-                                  selectedValue !==
-                                    queryableItem.ENUM_ALL_VALUE && (
-                                    <Button
-                                      primary
-                                      title="Aggiungi un altro filtro della stessa categoria"
-                                      css={`
-                                        min-width: 32px;
-                                        height: 34px;
-                                        border-radius: 2px;
-                                        margin-left: 6px;
-                                        padding: 0 8px;
-                                        display: flex;
-                                        align-items: center;
-                                        justify-content: center;
-                                        font-weight: bold;
-                                      `}
-                                      onClick={() =>
-                                        runInAction(() => {
-                                          item.setQuery(propertyName, [
-                                            ...enumRows,
-                                            ""
-                                          ]);
-                                        })
-                                      }
-                                    >
-                                      +
-                                    </Button>
-                                  )}
+                                {(showAddButton || showRemoveButton) && (
+                                  <Box
+                                    style={{
+                                      display: "flex",
+                                      alignItems: "center",
+                                      marginLeft: "6px"
+                                    }}
+                                  >
+                                    {showAddButton && (
+                                      <Button
+                                        primary
+                                        title="Aggiungi un altro filtro della stessa categoria"
+                                        css={`
+                                          min-width: 32px;
+                                          height: 34px;
+                                          border-radius: 2px;
+                                          padding: 0 8px;
+                                          display: flex;
+                                          align-items: center;
+                                          justify-content: center;
+                                          font-weight: bold;
+                                        `}
+                                        onClick={() =>
+                                          runInAction(() => {
+                                            item.setQuery(propertyName, [
+                                              ...enumRows,
+                                              ""
+                                            ]);
+                                          })
+                                        }
+                                      >
+                                        +
+                                      </Button>
+                                    )}
+                                    {showRemoveButton && (
+                                      <Button
+                                        primary
+                                        title="Rimuovi questo filtro"
+                                        css={`
+                                          min-width: 32px;
+                                          height: 34px;
+                                          border-radius: 2px;
+                                          padding: 0 8px;
+                                          display: flex;
+                                          align-items: center;
+                                          justify-content: center;
+                                          font-weight: bold;
+                                          margin-left: ${showAddButton
+                                            ? "6px"
+                                            : "0"};
+                                        `}
+                                        onClick={() =>
+                                          runInAction(() => {
+                                            const nextValues = enumRows.slice();
+                                            nextValues.splice(rowIndex, 1);
+                                            item.setQuery(
+                                              propertyName,
+                                              nextValues.length > 0
+                                                ? nextValues
+                                                : [""]
+                                            );
+                                          })
+                                        }
+                                      >
+                                        -
+                                      </Button>
+                                    )}
+                                  </Box>
+                                )}
                               </Box>
                             );
                           })}

--- a/lib/ReactViews/Workbench/Controls/FilterFeaturesSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/FilterFeaturesSection.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { runInAction } from "mobx";
 import { BaseModel } from "../../../Models/Definition/Model";
 import Box from "../../../Styled/Box";
@@ -14,6 +14,7 @@ import Button, { RawButton } from "../../../Styled/Button";
 import Hr from "../../../Styled/Hr";
 import ViewState from "../../../ReactViewModels/ViewState";
 import { RER_POI_CATALOG_ITEM_TYPE } from "../../../ModelMixins/RerPoiHelpers";
+import Checkbox from "../../../Styled/Checkbox";
 
 interface PropsType {
   item: BaseModel;
@@ -23,7 +24,27 @@ interface PropsType {
 const FilterFeaturesSection: React.FC<PropsType> = observer(
   ({ item, viewState }: PropsType) => {
     const [showQuerySection, setShowQuerySection] = useState<boolean>(false);
+    const [openSelectDropdown, setOpenSelectDropdown] = useState<string | null>(
+      null
+    );
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
     const isRerPoiCatalogItem = item.type === RER_POI_CATALOG_ITEM_TYPE;
+
+    useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (
+          dropdownRef.current &&
+          !dropdownRef.current.contains(event.target as Node)
+        ) {
+          setOpenSelectDropdown(null);
+        }
+      };
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }, []);
 
     const toggleQuerySection = () => {
       setShowQuerySection((prevState) => !prevState);
@@ -112,133 +133,168 @@ const FilterFeaturesSection: React.FC<PropsType> = observer(
                       </StyledLabel>
                       <Spacing right={3} />
                       {property.type === "enum" && isRerPoiCatalogItem && (
-                        <Box column>
-                          {enumRows.map((rowValue, rowIndex) => {
-                            const selectedValue =
-                              rowValue.trim().length > 0
-                                ? rowValue
-                                : queryableItem.ENUM_ALL_VALUE;
-                            const isLastRow = rowIndex === enumRows.length - 1;
-                            const showAddButton =
-                              isLastRow &&
-                              selectedValue !== queryableItem.ENUM_ALL_VALUE;
-                            const showRemoveButton = rowIndex > 0;
+                        <Box
+                          column
+                          position="relative"
+                          style={{ flex: 1 }}
+                          ref={
+                            openSelectDropdown === propertyName
+                              ? dropdownRef
+                              : undefined
+                          }
+                        >
+                          <Button
+                            css={`
+                              background: ${(p: any) => p.theme.darkLighter};
+                              border: 1px solid ${(p: any) => p.theme.dark};
+                              border-radius: 2px;
+                              color: ${(p: any) => p.theme.textLight};
+                              display: flex;
+                              align-items: center;
+                              min-height: 34px;
+                              padding: 5px 10px;
+                              text-align: left;
+                              justify-content: space-between;
+                              width: 100%;
+                            `}
+                            onClick={() =>
+                              setOpenSelectDropdown(
+                                openSelectDropdown === propertyName
+                                  ? null
+                                  : propertyName
+                              )
+                            }
+                          >
+                            <TextSpan>
+                              {enumRows.filter(
+                                (v: string) =>
+                                  v &&
+                                  v !== queryableItem.ENUM_ALL_VALUE &&
+                                  v.toLowerCase() !== "--tutto" &&
+                                  v.toLowerCase() !== "--tutti"
+                              ).length > 0
+                                ? `${
+                                    enumRows.filter(
+                                      (v: string) =>
+                                        v &&
+                                        v !== queryableItem.ENUM_ALL_VALUE &&
+                                        v.toLowerCase() !== "--tutto" &&
+                                        v.toLowerCase() !== "--tutti"
+                                    ).length
+                                  } selezionati`
+                                : "Tutti"}
+                            </TextSpan>
+                            <StyledIcon
+                              glyph={
+                                openSelectDropdown === propertyName
+                                  ? GLYPHS.opened
+                                  : GLYPHS.closed
+                              }
+                              styledWidth="10px"
+                              light
+                            />
+                          </Button>
 
-                            return (
-                              <Box
-                                key={`${propertyName}-${rowIndex}`}
-                                styledMargin={
-                                  rowIndex < enumRows.length - 1
-                                    ? "0 0 8px 0"
-                                    : "0"
-                                }
-                                style={{
-                                  display: "flex",
-                                  alignItems: "center"
-                                }}
-                              >
-                                <Select
-                                  boxProps={{
-                                    fullWidth: false,
-                                    flex: 1,
-                                    styledMinWidth: "0"
-                                  }}
-                                  name={`${propertyName}-${rowIndex}`}
-                                  value={selectedValue}
-                                  onChange={(
-                                    e: React.ChangeEvent<HTMLSelectElement>
-                                  ) => {
-                                    runInAction(() => {
-                                      const nextValues = enumRows.slice();
-                                      nextValues[rowIndex] =
-                                        e.target.value ===
-                                        queryableItem.ENUM_ALL_VALUE
-                                          ? ""
-                                          : e.target.value;
-                                      item.setQuery(propertyName, nextValues);
-                                    });
-                                  }}
-                                >
-                                  {enumValues.map((value) => {
-                                    return (
-                                      <option key={value} value={value}>
-                                        {value}
-                                      </option>
-                                    );
-                                  })}
-                                </Select>
-                                {(showAddButton || showRemoveButton) && (
+                          {openSelectDropdown === propertyName && (
+                            <Box
+                              column
+                              css={`
+                                position: absolute;
+                                top: 100%;
+                                left: 0;
+                                min-width: 100%;
+                                width: max-content;
+                                z-index: 99;
+                                background: ${(p: any) => p.theme.darkLighter};
+                                border: 1px solid ${(p: any) => p.theme.dark};
+                                max-height: 250px;
+                                overflow-y: auto;
+                                margin-top: 2px;
+                                box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+                                border-radius: 2px;
+                              `}
+                            >
+                              {enumValues.map((value) => {
+                                const isAllValue =
+                                  value === queryableItem.ENUM_ALL_VALUE ||
+                                  value.toLowerCase() === "--tutto" ||
+                                  value.toLowerCase() === "--tutti";
+                                const hasActiveFilters =
+                                  enumRows.filter(
+                                    (v: string) =>
+                                      v &&
+                                      v !== queryableItem.ENUM_ALL_VALUE &&
+                                      v.toLowerCase() !== "--tutto" &&
+                                      v.toLowerCase() !== "--tutti"
+                                  ).length > 0;
+
+                                const isChecked = isAllValue
+                                  ? !hasActiveFilters
+                                  : enumRows.includes(value);
+
+                                return (
                                   <Box
-                                    style={{
-                                      display: "flex",
-                                      alignItems: "center",
-                                      marginLeft: "6px"
-                                    }}
+                                    key={value}
+                                    css={`
+                                      padding: 0;
+                                      &:hover {
+                                        background: ${(p: any) =>
+                                          p.theme.colorPrimary};
+                                      }
+                                    `}
                                   >
-                                    {showAddButton && (
-                                      <Button
-                                        primary
-                                        title="Aggiungi un altro filtro della stessa categoria"
-                                        css={`
-                                          min-width: 32px;
-                                          height: 34px;
-                                          border-radius: 2px;
-                                          padding: 0 8px;
-                                          display: flex;
-                                          align-items: center;
-                                          justify-content: center;
-                                          font-weight: bold;
-                                        `}
-                                        onClick={() =>
-                                          runInAction(() => {
-                                            item.setQuery(propertyName, [
-                                              ...enumRows,
-                                              ""
-                                            ]);
-                                          })
-                                        }
-                                      >
-                                        +
-                                      </Button>
-                                    )}
-                                    {showRemoveButton && (
-                                      <Button
-                                        primary
-                                        title="Rimuovi questo filtro"
-                                        css={`
-                                          min-width: 32px;
-                                          height: 34px;
-                                          border-radius: 2px;
-                                          padding: 0 8px;
-                                          display: flex;
-                                          align-items: center;
-                                          justify-content: center;
-                                          font-weight: bold;
-                                          margin-left: ${showAddButton
-                                            ? "6px"
-                                            : "0"};
-                                        `}
-                                        onClick={() =>
-                                          runInAction(() => {
-                                            const nextValues = enumRows.slice();
-                                            nextValues.splice(rowIndex, 1);
+                                    <Checkbox
+                                      title={value}
+                                      isChecked={isChecked}
+                                      onChange={() => {
+                                        runInAction(() => {
+                                          if (isAllValue) {
+                                            item.setQuery(propertyName, [""]);
+                                          } else {
+                                            const nextValues = new Set(
+                                              enumRows.filter(
+                                                (v: string) =>
+                                                  v &&
+                                                  v !==
+                                                    queryableItem.ENUM_ALL_VALUE &&
+                                                  v.toLowerCase() !==
+                                                    "--tutto" &&
+                                                  v.toLowerCase() !== "--tutti"
+                                              )
+                                            );
+                                            if (isChecked) {
+                                              nextValues.delete(value);
+                                            } else {
+                                              nextValues.add(value);
+                                            }
+                                            const valuesArr =
+                                              Array.from(nextValues);
                                             item.setQuery(
                                               propertyName,
-                                              nextValues.length > 0
-                                                ? nextValues
+                                              valuesArr.length > 0
+                                                ? valuesArr
                                                 : [""]
                                             );
-                                          })
-                                        }
-                                      >
-                                        -
-                                      </Button>
-                                    )}
+                                          }
+                                        });
+                                      }}
+                                      textProps={{
+                                        css: `
+                                          color: ${(p: any) =>
+                                            p.theme.textLight};
+                                          margin-left: 0;
+                                          padding: 8px 10px;
+                                          width: 100%;
+                                        `
+                                      }}
+                                    >
+                                      {value}
+                                    </Checkbox>
                                   </Box>
-                                )}
-                              </Box>
-                            );
-                          })}
+                                );
+                              })}
+                            </Box>
+                          )}
                         </Box>
                       )}
                       {property.type === "enum" && !isRerPoiCatalogItem && (

--- a/lib/Traits/TraitsClasses/QueryableCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/QueryableCatalogItemTraits.ts
@@ -109,6 +109,14 @@ export class QueryablePropertyTraits extends ModelTraits {
       "If true, on aggregation use the properties to distribute values (only if type is 'dictionary')"
   })
   distributionOnAggregation: boolean = false;
+
+  @primitiveTrait({
+    type: "boolean",
+    name: "loadValuesFromService",
+    description:
+      "Loads filter values once from the service instead of dynamically from visible features."
+  })
+  loadValuesFromService = false;
 }
 
 export default class QueryableCatalogItemTraits extends ModelTraits {

--- a/lib/Traits/TraitsClasses/RerPoiCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/RerPoiCatalogItemTraits.ts
@@ -41,6 +41,27 @@ export class PoiDomainStyleGroup extends ModelTraits {
 }
 
 @traitClass({
+  description:
+    "Level ID to camera height mapping for progressive POI filtering."
+})
+export class LevelIdCameraHeightMapping extends ModelTraits {
+  @primitiveTrait({
+    type: "number",
+    name: "Level ID",
+    description: "The zoom level ID from the RER3D POI service."
+  })
+  levelId: number = 0;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Camera height threshold (meters)",
+    description:
+      "The camera height threshold in meters at which this zoom level should be displayed. Converted from cartographic scale."
+  })
+  cameraHeightThreshold: number = 0;
+}
+
+@traitClass({
   description: `Creates a single item in the catalog from RER3D POI (Regione Emilia-Romagna 3D Points of Interest) service.
 
 This specialized feature server item provides dynamic viewport-based loading and custom styling for POI layers,
@@ -140,14 +161,6 @@ export default class RerPoiCatalogItemTraits extends mixTraits(
 
   @primitiveTrait({
     type: "number",
-    name: "Progressive level step",
-    description:
-      "The step size for filtering POI levels based on camera height. Used to reduce the number of features at intermediate zoom levels."
-  })
-  progressiveLevelStep: number = 1;
-
-  @primitiveTrait({
-    type: "number",
     name: "Query bbox padding ratio",
     description:
       "The padding ratio to apply to the viewport rectangle when querying features. A value of 0.2 means 20% padding on each side."
@@ -169,22 +182,6 @@ export default class RerPoiCatalogItemTraits extends mixTraits(
       "The maximum camera tilt angle in degrees. Applied when the RerPoi layer is shown to limit steep viewing angles."
   })
   cameraTiltLimitDegrees: number = 60;
-
-  @primitiveTrait({
-    type: "number",
-    name: "Progressive near camera height",
-    description:
-      "The camera height in meters below which level filtering starts to apply. Used for zoom-dependent POI filtering."
-  })
-  progressiveNearCameraHeight: number = 1800;
-
-  @primitiveTrait({
-    type: "number",
-    name: "Progressive far camera height",
-    description:
-      "The camera height in meters above which all POI levels are hidden. Used for zoom-dependent POI filtering."
-  })
-  progressiveFarCameraHeight: number = 140000;
 
   @primitiveTrait({
     type: "string",
@@ -215,6 +212,29 @@ export default class RerPoiCatalogItemTraits extends mixTraits(
       "The color of the stroke around icon symbols. Accepts CSS color strings."
   })
   iconStrokeColor: string = "#000000";
+
+  @objectArrayTrait({
+    type: LevelIdCameraHeightMapping,
+    idProperty: "levelId",
+    name: "Level ID camera height mappings",
+    description:
+      "Maps zoom level IDs to camera height thresholds in meters. Used for progressive POI filtering based on camera altitude. Thresholds are derived from cartographic scales and represent the camera altitude at which each level should be displayed."
+  })
+  levelIdMappings: LevelIdCameraHeightMapping[] = [
+    { levelId: 7, cameraHeightThreshold: 46223.24 },
+    { levelId: 8, cameraHeightThreshold: 23111.62 },
+    { levelId: 9, cameraHeightThreshold: 11555.81 },
+    { levelId: 10, cameraHeightThreshold: 5777.9 },
+    { levelId: 11, cameraHeightThreshold: 2888.95 },
+    { levelId: 12, cameraHeightThreshold: 1444.47 },
+    { levelId: 13, cameraHeightThreshold: 722.23 },
+    { levelId: 14, cameraHeightThreshold: 361.11 },
+    { levelId: 15, cameraHeightThreshold: 180.55 },
+    { levelId: 16, cameraHeightThreshold: 90.27 },
+    { levelId: 17, cameraHeightThreshold: 45.13 },
+    { levelId: 18, cameraHeightThreshold: 22.56 },
+    { levelId: 19, cameraHeightThreshold: 11.28 }
+  ];
 
   @objectArrayTrait({
     type: PoiDomainStyleGroup,

--- a/lib/Traits/TraitsClasses/RerPoiCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/RerPoiCatalogItemTraits.ts
@@ -64,6 +64,41 @@ export default class RerPoiCatalogItemTraits extends mixTraits(
   nameField: string = "NOME";
 
   @primitiveTrait({
+    type: "boolean",
+    name: "Show labels",
+    description: "Whether to show labels for POI markers."
+  })
+  showLabels: boolean = false;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Label text color",
+    description: "The color of the label text for POI markers."
+  })
+  labelTextColor: string = "#ffffff";
+
+  @primitiveTrait({
+    type: "number",
+    name: "Label font size",
+    description: "The font size in pixels for POI marker labels."
+  })
+  labelFontSize: number = 12;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Label outline width",
+    description: "The outline width in pixels for POI marker labels."
+  })
+  labelOutlineWidth: number = 3;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Label outline color",
+    description: "The outline color for POI marker labels."
+  })
+  labelOutlineColor: string = "rgba(0, 0, 0, 0.65)";
+
+  @primitiveTrait({
     type: "string",
     name: "Scale field",
     description:

--- a/lib/Traits/TraitsClasses/RerPoiCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/RerPoiCatalogItemTraits.ts
@@ -1,0 +1,269 @@
+import objectArrayTrait from "../Decorators/objectArrayTrait";
+import primitiveArrayTrait from "../Decorators/primitiveArrayTrait";
+import primitiveTrait from "../Decorators/primitiveTrait";
+import ModelTraits from "../ModelTraits";
+import { traitClass } from "../Trait";
+import mixTraits from "../mixTraits";
+import ArcGisFeatureServerCatalogItemTraits from "./ArcGisFeatureServerCatalogItemTraits";
+
+@traitClass({
+  description: "POI domain style group."
+})
+export class PoiDomainStyleGroup extends ModelTraits {
+  @primitiveTrait({
+    type: "string",
+    name: "ID",
+    description: "Unique identifier for this style group."
+  })
+  id: string = "";
+
+  @primitiveTrait({
+    type: "string",
+    name: "Symbol",
+    description: "The Maki icon symbol to use for this group of POI domains."
+  })
+  symbol: string = "marker";
+
+  @primitiveTrait({
+    type: "string",
+    name: "Color",
+    description:
+      "The marker color to use for this group of POI domains. Accepts CSS color strings."
+  })
+  color?: string;
+
+  @primitiveArrayTrait({
+    type: "number",
+    name: "Domain IDs",
+    description: "The domain IDs that share this POI marker style."
+  })
+  domainIds: number[] = [];
+}
+
+@traitClass({
+  description: `Creates a single item in the catalog from RER3D POI (Regione Emilia-Romagna 3D Points of Interest) service.
+
+This specialized feature server item provides dynamic viewport-based loading and custom styling for POI layers,
+with zoom-level aware filtering and support for domain-based icon/color mapping.`,
+  example: {
+    url: "https://servizigis.regione.emilia-romagna.it/geoags/rest/services/portale/rer3d_poi/MapServer/0",
+    type: "rer-poi",
+    name: "RER POI",
+    id: "rer-poi"
+  }
+})
+export default class RerPoiCatalogItemTraits extends mixTraits(
+  ArcGisFeatureServerCatalogItemTraits
+) {
+  @primitiveTrait({
+    type: "string",
+    name: "Name field",
+    description:
+      "The name of the feature attribute field that contains the POI name."
+  })
+  nameField: string = "NOME";
+
+  @primitiveTrait({
+    type: "string",
+    name: "Scale field",
+    description:
+      "The name of the feature attribute field that defines the visibility scale/distance for each POI."
+  })
+  scaleField: string = "SCALA";
+
+  @primitiveTrait({
+    type: "string",
+    name: "Level ID field",
+    description:
+      "The name of the feature attribute field that contains the zoom level ID."
+  })
+  levelIdField: string = "LEVEL_ID";
+
+  @primitiveTrait({
+    type: "string",
+    name: "Domain ID field",
+    description:
+      "The name of the feature attribute field that contains the domain/category ID for styling."
+  })
+  domainIdField: string = "ID_DOMINIO";
+
+  @primitiveTrait({
+    type: "number",
+    name: "Minimum level ID",
+    description:
+      "The minimum zoom level ID to request from the service. Lower values represent farther zoom levels."
+  })
+  minLevelId: number = 7;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Maximum level ID",
+    description:
+      "The maximum zoom level ID to request from the service. Higher values represent closer zoom levels."
+  })
+  maxLevelId: number = 19;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Progressive level step",
+    description:
+      "The step size for filtering POI levels based on camera height. Used to reduce the number of features at intermediate zoom levels."
+  })
+  progressiveLevelStep: number = 1;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Query bbox padding ratio",
+    description:
+      "The padding ratio to apply to the viewport rectangle when querying features. A value of 0.2 means 20% padding on each side."
+  })
+  queryBboxPaddingRatio: number = 0.2;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Dynamic request debounce (ms)",
+    description:
+      "The debounce time in milliseconds for viewport change requests. Prevents excessive server requests during camera movement."
+  })
+  dynamicRequestDebounceMs: number = 350;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Camera tilt limit (degrees)",
+    description:
+      "The maximum camera tilt angle in degrees. Applied when the RerPoi layer is shown to limit steep viewing angles."
+  })
+  cameraTiltLimitDegrees: number = 60;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Progressive near camera height",
+    description:
+      "The camera height in meters below which level filtering starts to apply. Used for zoom-dependent POI filtering."
+  })
+  progressiveNearCameraHeight: number = 1800;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Progressive far camera height",
+    description:
+      "The camera height in meters above which all POI levels are hidden. Used for zoom-dependent POI filtering."
+  })
+  progressiveFarCameraHeight: number = 140000;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Default marker color",
+    description:
+      "The default color for POI markers when no domain-specific color is defined. Accepts CSS color strings."
+  })
+  defaultMarkerColor: string = "royalblue";
+
+  @primitiveTrait({
+    type: "number",
+    name: "Marker size (pixels)",
+    description: "The size of marker icons in pixels."
+  })
+  markerSize: number = 48;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Icon stroke width",
+    description: "The width of the stroke around icon symbols in pixels."
+  })
+  iconStrokeWidth: number = 1;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Icon stroke color",
+    description:
+      "The color of the stroke around icon symbols. Accepts CSS color strings."
+  })
+  iconStrokeColor: string = "#000000";
+
+  @objectArrayTrait({
+    type: PoiDomainStyleGroup,
+    idProperty: "id",
+    name: "POI domain style groups",
+    description:
+      "Defines the mapping between domain IDs and their associated icon symbols and colors."
+  })
+  poiDomainStyleGroups: PoiDomainStyleGroup[] = [
+    {
+      id: "group-1",
+      symbol: "village",
+      domainIds: [1, 2]
+    },
+    {
+      id: "group-2",
+      symbol: "industrial",
+      domainIds: [3]
+    },
+    {
+      id: "group-3",
+      symbol: "village",
+      color: "#ff0",
+      domainIds: [4]
+    },
+    {
+      id: "group-4",
+      symbol: "village",
+      color: "#333",
+      domainIds: [5]
+    },
+    {
+      id: "group-5",
+      symbol: "village",
+      color: "#fff",
+      domainIds: [6]
+    },
+    {
+      id: "group-6",
+      symbol: "square",
+      domainIds: [7]
+    },
+    {
+      id: "group-7",
+      symbol: "cross",
+      domainIds: [8]
+    },
+    {
+      id: "group-8",
+      symbol: "mountain",
+      color: "#ff00ff",
+      domainIds: [9]
+    },
+    {
+      id: "group-9",
+      symbol: "triangle",
+      domainIds: [10]
+    },
+    {
+      id: "group-10",
+      symbol: "triangle-stroked",
+      domainIds: [11]
+    },
+    {
+      id: "group-11",
+      symbol: "marker",
+      domainIds: [12, 15, 19, 20, 21, 22, 24]
+    },
+    {
+      id: "group-12",
+      symbol: "water",
+      domainIds: [13, 14, 16, 17, 18, 23]
+    },
+    {
+      id: "group-13",
+      symbol: "town",
+      domainIds: [601]
+    },
+    {
+      id: "group-14",
+      symbol: "city",
+      domainIds: [602, 603]
+    }
+  ];
+}
+
+export const defaultRerPoiCatalogItemTraits = new RerPoiCatalogItemTraits();

--- a/lib/Traits/TraitsClasses/RerPoiCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/RerPoiCatalogItemTraits.ts
@@ -56,6 +56,14 @@ export default class RerPoiCatalogItemTraits extends mixTraits(
   ArcGisFeatureServerCatalogItemTraits
 ) {
   @primitiveTrait({
+    type: "boolean",
+    name: "Show debug bounding box",
+    description:
+      "Whether to display the camera viewport and padded query bounding boxes on the map."
+  })
+  showDebugBBox: boolean = false;
+
+  @primitiveTrait({
     type: "string",
     name: "Name field",
     description:

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "javascript-natural-sort": "^0.7.1",
     "json5": "^2.1.0",
     "leaflet": "^1.8.0",
+    "leaflet.markercluster": "^1.5.3",
     "linkify-it": "^5.0.0",
     "lodash-es": "^4.17.11",
     "markdown-it": "^14.1.0",

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -1169,7 +1169,8 @@
       "reachedMaxFeatureLimit": "Warning: This layer has reached the FeatureService feature limit ({{maxFeatures}})."
     },
     "rerPoiCatalogItem": {
-      "exceededCameraTiltLimit": "Warning: The camera tilt angle limit ({{cameraTiltLimitDegrees}}°) has been exceeded. To view new POIs, you must reset the camera tilt angle correctly."
+      "exceededCameraTiltLimit": "Warning: The camera tilt angle limit ({{cameraTiltLimitDegrees}}°) has been exceeded. To view new POIs, you must reset the camera tilt angle correctly.",
+      "noVisiblePoints": "Warning: No POIs are visible in the current view."
     },
     "arcGisMapServerCatalogGroup": {
       "name": "ArcGIS Map Server Group",

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -1168,6 +1168,9 @@
       "invalidServiceMessage": "An error occurred while invoking the ArcGIS Feature Service.  The server's response does not appear to be a valid Feature Service layer.",
       "reachedMaxFeatureLimit": "Warning: This layer has reached the FeatureService feature limit ({{maxFeatures}})."
     },
+    "rerPoiCatalogItem": {
+      "exceededCameraTiltLimit": "Warning: The camera tilt angle limit ({{cameraTiltLimitDegrees}}°) has been exceeded. To view new POIs, you must reset the camera tilt angle correctly."
+    },
     "arcGisMapServerCatalogGroup": {
       "name": "ArcGIS Map Server Group",
       "dataDescription": "Data Description",

--- a/wwwroot/languages/it/translation.json
+++ b/wwwroot/languages/it/translation.json
@@ -903,6 +903,9 @@
       "invalidServiceMessage": "Si è verificato un errore durante l'invocazione di ArcGIS Feature Service.  La risposta del server non sembra essere un livello Feature Service valido.",
       "missingUrlMessage": "Impossibile caricare l'endpoint ArcGis FeatureServer perché l'elemento del catalogo non ha un `url`."
     },
+    "rerPoiCatalogItem": {
+      "exceededCameraTiltLimit": "Attenzione: Il limite dell'angolo di inclinazione della camera ({{cameraTiltLimitDegrees}}°) è stato superato. Per poter visualizzare nuovi POI è necessario reimpostare l'angolo di inclinazione della camera in maniera corretta."
+    },
     "arcGisFeatureServerCatalogGroup": {
       "serviceDescription": "Descrizione del Servizio",
       "dataDescription": "Descrizione dei Dati",

--- a/wwwroot/languages/it/translation.json
+++ b/wwwroot/languages/it/translation.json
@@ -904,7 +904,8 @@
       "missingUrlMessage": "Impossibile caricare l'endpoint ArcGis FeatureServer perché l'elemento del catalogo non ha un `url`."
     },
     "rerPoiCatalogItem": {
-      "exceededCameraTiltLimit": "Attenzione: Il limite dell'angolo di inclinazione della camera ({{cameraTiltLimitDegrees}}°) è stato superato. Per poter visualizzare nuovi POI è necessario reimpostare l'angolo di inclinazione della camera in maniera corretta."
+      "exceededCameraTiltLimit": "Attenzione: Il limite dell'angolo di inclinazione della camera ({{cameraTiltLimitDegrees}}°) è stato superato. Per poter visualizzare nuovi POI è necessario reimpostare l'angolo di inclinazione della camera in maniera corretta.",
+      "noVisiblePoints": "Attenzione: non ci sono POI visibili nella vista corrente."
     },
     "arcGisFeatureServerCatalogGroup": {
       "serviceDescription": "Descrizione del Servizio",


### PR DESCRIPTION
Introduced a new RerPoiCatalogItem, extending ArcGisFeatureServerCatalogItem, to provide dedicated support for RER POI datasets. Improved clustering behavior and Leaflet integration, ensuring more consistent cluster rendering and enhanced support for GeoJSON and Esri FeatureServer catalog items. Additionally, it streamlines catalog member registration and type mapping while including various fixes and refactorings.